### PR TITLE
feat: complete Supabase client integration (Issue #2)

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -13,13 +13,14 @@ import {
 import { Link, router } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import * as AuthSession from 'expo-auth-session';
-import { supabase } from '@/lib/supabase';
+import { useAuth } from '@/contexts/AuthContext';
 import { validateSignInForm } from '@/lib/validation';
 import Colors from '@/constants/Colors';
 
 WebBrowser.maybeCompleteAuthSession();
 
 export default function SignIn() {
+  const { signIn } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -40,10 +41,7 @@ export default function SignIn() {
 
     setLoading(true);
     try {
-      const { error } = await supabase.auth.signInWithPassword({
-        email: email.trim(),
-        password,
-      });
+      const { error } = await signIn(email.trim(), password);
 
       if (error) {
         Alert.alert('Sign In Error', error.message);

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -14,13 +14,14 @@ import {
 import { Link, router } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import * as AuthSession from 'expo-auth-session';
-import { supabase } from '@/lib/supabase';
+import { useAuth } from '@/contexts/AuthContext';
 import { validateSignUpForm } from '@/lib/validation';
 import Colors from '@/constants/Colors';
 
 WebBrowser.maybeCompleteAuthSession();
 
 export default function SignUp() {
+  const { signUp } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -44,10 +45,7 @@ export default function SignUp() {
 
     setLoading(true);
     try {
-      const { error } = await supabase.auth.signUp({
-        email: email.trim(),
-        password,
-      });
+      const { error } = await signUp(email.trim(), password);
 
       if (error) {
         Alert.alert('Sign Up Error', error.message);

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -7,6 +7,9 @@ type AuthContextType = {
   session: Session | null;
   user: User | null;
   loading: boolean;
+  signIn: (email: string, password: string) => Promise<{ error: Error | null }>;
+  signUp: (email: string, password: string) => Promise<{ error: Error | null }>;
+  signInWithGoogle: () => Promise<{ error: Error | null }>;
   signOut: () => Promise<void>;
 };
 
@@ -14,6 +17,9 @@ const AuthContext = createContext<AuthContextType>({
   session: null,
   user: null,
   loading: true,
+  signIn: async () => ({ error: null }),
+  signUp: async () => ({ error: null }),
+  signInWithGoogle: async () => ({ error: null }),
   signOut: async () => {},
 });
 
@@ -91,12 +97,38 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
+  const signIn = async (email: string, password: string) => {
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    return { error };
+  };
+
+  const signUp = async (email: string, password: string) => {
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+    });
+    return { error };
+  };
+
+  const signInWithGoogle = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: 'com.discr.app://',
+      },
+    });
+    return { error };
+  };
+
   const signOut = async () => {
     await supabase.auth.signOut();
   };
 
   return (
-    <AuthContext.Provider value={{ session, user, loading, signOut }}>
+    <AuthContext.Provider value={{ session, user, loading, signIn, signUp, signInWithGoogle, signOut }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary

Completes the Supabase client integration by adding the missing auth functions to AuthContext, meeting all acceptance criteria for Issue #2.

## Changes

### AuthContext Updates
- ✅ Added `signIn(email, password)` function
- ✅ Added `signUp(email, password)` function  
- ✅ Added `signInWithGoogle()` function
- All functions return `{ error: Error | null }` for consistent error handling

### Screen Updates
- Updated `app/(auth)/sign-in.tsx` to use `signIn` from `useAuth()` hook
- Updated `app/(auth)/sign-up.tsx` to use `signUp` from `useAuth()` hook
- Removed direct `supabase` imports from auth screens

## Acceptance Criteria Met

- [x] `@supabase/supabase-js` installed in mobile app
- [x] Supabase client initialized with project URL and anon key
- [x] Auth state listener set up (onAuthStateChange)
- [x] Secure storage for session tokens (AsyncStorage)
- [x] Auth context/provider wrapping app for global auth state
- [x] `useAuth()` hook available returning:
  - [x] `user` - current user object or null
  - [x] `session` - current session or null
  - [x] `loading` - boolean for auth state loading
  - [x] `signIn(email, password)` - function ✨ **NEW**
  - [x] `signUp(email, password)` - function ✨ **NEW**
  - [x] `signInWithGoogle()` - function ✨ **NEW**
  - [x] `signOut()` - function

## Testing

All existing tests continue to pass:
- ✅ 25 tests passing
- ✅ Validation tests (21 tests)
- ✅ AuthContext tests (3 tests)
- ✅ Component snapshot tests (1 test)

## Usage Example

```typescript
import { useAuth } from '@/contexts/AuthContext';

function MyComponent() {
  const { user, session, loading, signIn, signUp, signInWithGoogle, signOut } = useAuth();
  
  const handleSignIn = async () => {
    const { error } = await signIn('user@example.com', 'password123');
    if (error) {
      console.error('Sign in failed:', error.message);
    }
  };
  
  return <View>...</View>;
}
```

## Related Issues

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)