### PR TITLE
feat: improve recovery UX across the app

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,7 +11,7 @@
     "splash": {
       "image": "./assets/images/splash-icon.png",
       "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
+      "backgroundColor": "#3b1877"
     },
     "ios": {
       "supportsTablet": true,

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -221,6 +221,7 @@ const styles = StyleSheet.create({
     padding: 12,
     fontSize: 16,
     backgroundColor: '#fff',
+    color: '#000',
   },
   inputError: {
     borderColor: '#ef4444',

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -265,6 +265,7 @@ const styles = StyleSheet.create({
     padding: 12,
     fontSize: 16,
     backgroundColor: '#fff',
+    color: '#000',
   },
   inputError: {
     borderColor: '#ef4444',

--- a/app/(tabs)/my-bag.tsx
+++ b/app/(tabs)/my-bag.tsx
@@ -29,6 +29,13 @@ interface DiscPhoto {
   created_at: string;
 }
 
+interface ActiveRecovery {
+  id: string;
+  status: string;
+  finder_id: string;
+  found_at: string;
+}
+
 interface Disc {
   id: string;
   name: string;
@@ -42,7 +49,15 @@ interface Disc {
   notes?: string;
   created_at: string;
   photos: DiscPhoto[];
+  active_recovery?: ActiveRecovery | null;
 }
+
+// Recovery status labels and colors
+const RECOVERY_STATUS_MAP: Record<string, { label: string; color: string }> = {
+  found: { label: 'Found', color: '#F39C12' },
+  meetup_proposed: { label: 'Meetup Proposed', color: '#3498DB' },
+  meetup_confirmed: { label: 'Meetup Confirmed', color: '#27AE60' },
+};
 
 // Color mapping with hex values
 const COLOR_MAP: Record<string, string> = {
@@ -138,7 +153,16 @@ export default function MyBagScreen() {
 
         {/* Disc Info */}
         <View style={styles.discInfo}>
-          <Text style={styles.discName}>{item.mold || item.name}</Text>
+          <View style={styles.discNameRow}>
+            <Text style={styles.discName}>{item.mold || item.name}</Text>
+            {item.active_recovery && RECOVERY_STATUS_MAP[item.active_recovery.status] && (
+              <View style={[styles.recoveryBadge, { backgroundColor: RECOVERY_STATUS_MAP[item.active_recovery.status].color }]}>
+                <Text style={styles.recoveryBadgeText}>
+                  {RECOVERY_STATUS_MAP[item.active_recovery.status].label}
+                </Text>
+              </View>
+            )}
+          </View>
           {item.manufacturer && <Text style={styles.discDetails}>{item.manufacturer}</Text>}
           {item.plastic && <Text style={styles.discMeta}>{item.plastic}</Text>}
           <View style={styles.discFooter}>
@@ -269,10 +293,26 @@ const styles = StyleSheet.create({
   discInfo: {
     flex: 1,
   },
+  discNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 4,
+    flexWrap: 'wrap',
+  },
   discName: {
     fontSize: 18,
     fontWeight: '600',
-    marginBottom: 4,
+  },
+  recoveryBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  recoveryBadgeText: {
+    color: '#fff',
+    fontSize: 10,
+    fontWeight: '600',
   },
   discDetails: {
     fontSize: 14,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -87,6 +87,8 @@ function RootLayoutNav() {
         <Stack.Screen name="add-disc" options={{ presentation: 'modal', title: 'Add Disc' }} />
         <Stack.Screen name="disc/[id]" options={{ title: 'Disc Details' }} />
         <Stack.Screen name="edit-disc/[id]" options={{ presentation: 'modal', title: 'Edit Disc' }} />
+        <Stack.Screen name="recovery/[id]" options={{ title: 'Recovery Details' }} />
+        <Stack.Screen name="propose-meetup/[id]" options={{ presentation: 'modal', title: 'Propose Meetup' }} />
         <Stack.Screen name="d/[code]" options={{ headerShown: false }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
       </Stack>

--- a/app/disc/[id].tsx
+++ b/app/disc/[id].tsx
@@ -38,6 +38,20 @@ interface QRCodeInfo {
   status: string;
 }
 
+interface ActiveRecovery {
+  id: string;
+  status: string;
+  finder_id: string;
+  found_at: string;
+}
+
+// Recovery status labels and colors
+const RECOVERY_STATUS_MAP: Record<string, { label: string; color: string }> = {
+  found: { label: 'Found', color: '#F39C12' },
+  meetup_proposed: { label: 'Meetup Proposed', color: '#3498DB' },
+  meetup_confirmed: { label: 'Meetup Confirmed', color: '#27AE60' },
+};
+
 interface Disc {
   id: string;
   name: string;
@@ -53,6 +67,7 @@ interface Disc {
   photos: DiscPhoto[];
   qr_code_id?: string;
   qr_code?: QRCodeInfo;
+  active_recovery?: ActiveRecovery | null;
 }
 
 // Color mapping with hex values
@@ -279,6 +294,20 @@ export default function DiscDetailScreen() {
       <View style={styles.infoSection}>
         <Text style={styles.title}>{disc.mold || disc.name}</Text>
 
+        {/* Recovery Status Banner */}
+        {disc.active_recovery && RECOVERY_STATUS_MAP[disc.active_recovery.status] && (
+          <Pressable
+            style={[styles.recoveryBanner, { backgroundColor: RECOVERY_STATUS_MAP[disc.active_recovery.status].color }]}
+            onPress={() => router.push(`/recovery/${disc.active_recovery!.id}`)}
+          >
+            <FontAwesome name="refresh" size={16} color="#fff" />
+            <Text style={styles.recoveryBannerText}>
+              {RECOVERY_STATUS_MAP[disc.active_recovery.status].label} - Tap for details
+            </Text>
+            <FontAwesome name="chevron-right" size={14} color="#fff" />
+          </Pressable>
+        )}
+
         {/* Manufacturer */}
         {disc.manufacturer && <Text style={styles.manufacturer}>{disc.manufacturer}</Text>}
 
@@ -490,6 +519,22 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontWeight: 'bold',
     marginBottom: 8,
+  },
+  recoveryBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    marginBottom: 16,
+  },
+  recoveryBannerText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '600',
+    flex: 1,
   },
   manufacturer: {
     fontSize: 18,

--- a/app/recovery/[id].tsx
+++ b/app/recovery/[id].tsx
@@ -8,6 +8,7 @@ import {
   Alert,
   Linking,
   RefreshControl,
+  View as RNView,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Text, View } from '@/components/Themed';
@@ -284,7 +285,7 @@ export default function RecoveryDetailScreen() {
       </View>
 
       {/* Disc Card */}
-      <View style={[styles.discCard, { borderColor: isDark ? '#444' : '#eee' }]}>
+      <View style={[styles.discCard, { borderColor: isDark ? '#444' : '#eee', backgroundColor: isDark ? '#1a1a1a' : '#fff' }]}>
         {recovery.disc?.photo_url ? (
           <Image source={{ uri: recovery.disc.photo_url }} style={styles.discPhoto} />
         ) : (
@@ -311,7 +312,7 @@ export default function RecoveryDetailScreen() {
       </View>
 
       {/* People Involved */}
-      <View style={[styles.section, { borderColor: isDark ? '#444' : '#eee' }]}>
+      <View style={[styles.section, { borderColor: isDark ? '#444' : '#eee', backgroundColor: isDark ? '#1a1a1a' : '#fff' }]}>
         <Text style={styles.sectionTitle}>People</Text>
         <View style={styles.personRow}>
           <FontAwesome name="user" size={16} color={Colors.violet.primary} />
@@ -329,7 +330,7 @@ export default function RecoveryDetailScreen() {
 
       {/* Finder Message */}
       {recovery.finder_message && (
-        <View style={[styles.section, { borderColor: isDark ? '#444' : '#eee' }]}>
+        <View style={[styles.section, { borderColor: isDark ? '#444' : '#eee', backgroundColor: isDark ? '#1a1a1a' : '#fff' }]}>
           <Text style={styles.sectionTitle}>Finder's Message</Text>
           <Text style={styles.messageText}>{recovery.finder_message}</Text>
           <Text style={styles.timestamp}>Found {formatDate(recovery.found_at)}</Text>
@@ -338,23 +339,23 @@ export default function RecoveryDetailScreen() {
 
       {/* Accepted Meetup */}
       {acceptedProposal && (
-        <View style={[styles.section, styles.acceptedSection]}>
+        <RNView style={[styles.section, styles.acceptedSection]}>
           <Text style={styles.sectionTitle}>
             <FontAwesome name="check-circle" size={18} color="#2ECC71" /> Confirmed Meetup
           </Text>
-          <View style={styles.meetupDetails}>
-            <View style={styles.meetupRow}>
+          <RNView style={styles.meetupDetails}>
+            <RNView style={styles.meetupRow}>
               <FontAwesome name="map-marker" size={16} color="#666" />
               <Text style={styles.meetupText}>{acceptedProposal.location_name}</Text>
-            </View>
-            <View style={styles.meetupRow}>
+            </RNView>
+            <RNView style={styles.meetupRow}>
               <FontAwesome name="calendar" size={16} color="#666" />
               <Text style={styles.meetupText}>{formatDate(acceptedProposal.proposed_datetime)}</Text>
-            </View>
+            </RNView>
             {acceptedProposal.message && (
               <Text style={styles.proposalMessage}>{acceptedProposal.message}</Text>
             )}
-          </View>
+          </RNView>
           <Pressable
             style={styles.directionsButton}
             onPress={() => handleGetDirections(acceptedProposal)}
@@ -378,29 +379,29 @@ export default function RecoveryDetailScreen() {
               )}
             </Pressable>
           )}
-        </View>
+        </RNView>
       )}
 
       {/* Pending Proposal (for owner to accept/decline) */}
       {isOwner && pendingProposal && (
-        <View style={[styles.section, styles.pendingSection]}>
+        <RNView style={[styles.section, styles.pendingSection]}>
           <Text style={styles.sectionTitle}>
             <FontAwesome name="clock-o" size={18} color="#F39C12" /> Pending Meetup Proposal
           </Text>
-          <View style={styles.meetupDetails}>
-            <View style={styles.meetupRow}>
+          <RNView style={styles.meetupDetails}>
+            <RNView style={styles.meetupRow}>
               <FontAwesome name="map-marker" size={16} color="#666" />
               <Text style={styles.meetupText}>{pendingProposal.location_name}</Text>
-            </View>
-            <View style={styles.meetupRow}>
+            </RNView>
+            <RNView style={styles.meetupRow}>
               <FontAwesome name="calendar" size={16} color="#666" />
               <Text style={styles.meetupText}>{formatDate(pendingProposal.proposed_datetime)}</Text>
-            </View>
+            </RNView>
             {pendingProposal.message && (
               <Text style={styles.proposalMessage}>{pendingProposal.message}</Text>
             )}
-          </View>
-          <View style={styles.actionButtons}>
+          </RNView>
+          <RNView style={styles.actionButtons}>
             <Pressable
               style={[styles.acceptButton, actionLoading && styles.buttonDisabled]}
               onPress={() => handleAcceptMeetup(pendingProposal.id)}
@@ -423,8 +424,8 @@ export default function RecoveryDetailScreen() {
               <FontAwesome name="times" size={16} color="#E74C3C" />
               <Text style={styles.declineButtonText}>Decline</Text>
             </Pressable>
-          </View>
-        </View>
+          </RNView>
+        </RNView>
       )}
 
       {/* Finder: Propose Meetup button */}
@@ -440,7 +441,7 @@ export default function RecoveryDetailScreen() {
 
       {/* Finder: Waiting for owner */}
       {!isOwner && pendingProposal && (
-        <View style={[styles.section, { borderColor: isDark ? '#444' : '#eee' }]}>
+        <View style={[styles.section, { borderColor: isDark ? '#444' : '#eee', backgroundColor: isDark ? '#1a1a1a' : '#fff' }]}>
           <View style={styles.waitingRow}>
             <FontAwesome name="clock-o" size={20} color="#F39C12" />
             <Text style={styles.waitingText}>Waiting for owner to respond to your meetup proposal</Text>
@@ -613,11 +614,11 @@ const styles = StyleSheet.create({
   },
   acceptedSection: {
     borderColor: '#2ECC71',
-    backgroundColor: 'rgba(46, 204, 113, 0.05)',
+    backgroundColor: 'rgba(46, 204, 113, 0.1)',
   },
   pendingSection: {
     borderColor: '#F39C12',
-    backgroundColor: 'rgba(243, 156, 18, 0.05)',
+    backgroundColor: 'rgba(243, 156, 18, 0.1)',
   },
   meetupDetails: {
     marginBottom: 12,

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -124,7 +124,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   const signOut = async () => {
-    await supabase.auth.signOut();
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error('Sign out error:', error);
+    }
+    // Force clear state even if signOut fails
+    setSession(null);
+    setUser(null);
   };
 
   return (


### PR DESCRIPTION
## Summary
- Add owner's pending recoveries to Found Disc tab - prominent alert when your disc was found
- Add recovery status badge to My Bag disc list showing "Found", "Meetup Proposed", or "Meetup Confirmed"
- Add recovery banner to disc detail page linking directly to recovery details
- Add "Discs I Found" section to profile tab for finders
- Add finder stats (found/returned counts) to profile header
- Fix recovery detail screen styling (white box issue on dark mode)
- Fix header title showing "recovery/[id]" instead of "Recovery Details"
- Fix dark mode text input colors on auth screens
- Fix splash screen background color for Android
- Fix QR code URL parsing when scanning

## Test plan
- [ ] As disc owner with active recovery, verify "Your Discs Were Found!" shows on Found Disc tab
- [ ] As disc owner, verify recovery status badge shows on My Bag
- [ ] As disc owner, verify recovery banner shows on disc detail page
- [ ] As finder, verify "Discs I Found" section shows on profile
- [ ] Verify found/returned stats show correctly on profile
- [ ] Verify recovery detail screen has no white boxes on dark mode
- [ ] Verify auth screen text inputs are readable in dark mode
- [ ] Verify Android splash screen has purple background

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)