### PR TITLE
feat: add dismiss all notifications and fix surrendered disc display

### DIFF
--- a/app/(tabs)/found-disc.tsx
+++ b/app/(tabs)/found-disc.tsx
@@ -167,7 +167,7 @@ export default function FoundDiscScreen() {
           disc:discs(id, name, manufacturer, mold, plastic, color)
         `)
         .in('disc_id', discIds)
-        .not('status', 'in', '("recovered","cancelled")')
+        .not('status', 'in', '("recovered","cancelled","surrendered")')
         .order('created_at', { ascending: false });
 
       if (recoveriesError) {


### PR DESCRIPTION
## Summary
- Add "Dismiss all" button to notifications header for bulk dismissal
- Exclude `surrendered` status from "Your Discs Were Found" section on Found Disc tab
- Show header with notification count even when all notifications are read

## Test plan
- [ ] Test "Dismiss all" button clears all notifications
- [ ] Verify surrendered discs no longer appear in "Your Discs Were Found"
- [ ] Confirm header shows "X notifications" when all are read

**Depends on:** API PR for dismiss_all support

🤖 Generated with [Claude Code](https://claude.com/claude-code)