### PR TITLE
feat: add surrender disc functionality and badges

### DIFF
--- a/app/(tabs)/my-bag.tsx
+++ b/app/(tabs)/my-bag.tsx
@@ -50,6 +50,8 @@ interface Disc {
   created_at: string;
   photos: DiscPhoto[];
   active_recovery?: ActiveRecovery | null;
+  was_surrendered?: boolean;
+  surrendered_at?: string | null;
 }
 
 // Recovery status labels and colors
@@ -155,6 +157,12 @@ export default function MyBagScreen() {
         <View style={styles.discInfo}>
           <View style={styles.discNameRow}>
             <Text style={styles.discName}>{item.mold || item.name}</Text>
+            {item.was_surrendered && (
+              <View style={[styles.recoveryBadge, styles.surrenderedBadge]}>
+                <FontAwesome name="gift" size={10} color="#fff" />
+                <Text style={styles.recoveryBadgeText}>Surrendered</Text>
+              </View>
+            )}
             {item.active_recovery && RECOVERY_STATUS_MAP[item.active_recovery.status] && (
               <View style={[styles.recoveryBadge, { backgroundColor: RECOVERY_STATUS_MAP[item.active_recovery.status].color }]}>
                 <Text style={styles.recoveryBadgeText}>
@@ -305,6 +313,9 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   recoveryBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
     paddingHorizontal: 8,
     paddingVertical: 2,
     borderRadius: 10,
@@ -313,6 +324,9 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 10,
     fontWeight: '600',
+  },
+  surrenderedBadge: {
+    backgroundColor: '#9B59B6',
   },
   discDetails: {
     fontSize: 14,

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -19,7 +19,7 @@ import { useColorScheme } from '@/components/useColorScheme';
 
 interface Notification {
   id: string;
-  type: 'disc_found' | 'meetup_proposed' | 'meetup_accepted' | 'meetup_declined' | 'disc_recovered';
+  type: 'disc_found' | 'meetup_proposed' | 'meetup_accepted' | 'meetup_declined' | 'disc_recovered' | 'disc_surrendered';
   title: string;
   body: string;
   data: {
@@ -37,6 +37,7 @@ const NOTIFICATION_ICONS: Record<string, React.ComponentProps<typeof FontAwesome
   meetup_accepted: 'check-circle',
   meetup_declined: 'times-circle',
   disc_recovered: 'trophy',
+  disc_surrendered: 'gift',
 };
 
 const NOTIFICATION_COLORS: Record<string, string> = {
@@ -45,6 +46,7 @@ const NOTIFICATION_COLORS: Record<string, string> = {
   meetup_accepted: '#27AE60',
   meetup_declined: '#E74C3C',
   disc_recovered: '#10b981',
+  disc_surrendered: '#9B59B6',
 };
 
 export default function NotificationsScreen() {

--- a/app/(tabs)/two.tsx
+++ b/app/(tabs)/two.tsx
@@ -258,7 +258,7 @@ export default function ProfileScreen() {
           disc:discs(id, name, manufacturer, mold, color)
         `)
         .in('disc_id', discIds)
-        .not('status', 'in', '("recovered","cancelled")')
+        .not('status', 'in', '("recovered","cancelled","surrendered")')
         .order('created_at', { ascending: false });
 
       if (recoveriesError) {
@@ -302,7 +302,7 @@ export default function ProfileScreen() {
           disc:discs(id, name, manufacturer, mold, color)
         `)
         .eq('finder_id', user.id)
-        .not('status', 'in', '("recovered","cancelled")')
+        .not('status', 'in', '("recovered","cancelled","surrendered")')
         .order('created_at', { ascending: false });
 
       if (recoveriesError) {

--- a/app/disc/[id].tsx
+++ b/app/disc/[id].tsx
@@ -68,6 +68,8 @@ interface Disc {
   qr_code_id?: string;
   qr_code?: QRCodeInfo;
   active_recovery?: ActiveRecovery | null;
+  was_surrendered?: boolean;
+  surrendered_at?: string | null;
 }
 
 // Color mapping with hex values
@@ -258,6 +260,14 @@ export default function DiscDetailScreen() {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.scrollContent}>
+      {/* Surrendered Banner */}
+      {disc.was_surrendered && (
+        <RNView style={styles.surrenderedBanner}>
+          <FontAwesome name="gift" size={18} color="#fff" />
+          <Text style={styles.surrenderedBannerText}>This disc was surrendered to you</Text>
+        </RNView>
+      )}
+
       {/* Photo Gallery - Circular Display */}
       {validPhotos.length > 0 ? (
         <View style={styles.photoGalleryContainer}>
@@ -667,6 +677,22 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   deleteButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  surrenderedBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    backgroundColor: '#9B59B6',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+    marginBottom: 20,
+  },
+  surrenderedBannerText: {
     color: '#fff',
     fontSize: 16,
     fontWeight: '600',


### PR DESCRIPTION
## Summary
- Add surrender disc button to recovery details (owner only, during active recovery)
- Add surrendered section UI in recovery details with "View in My Collection" button for finder
- Add purple "Surrendered" badge to disc cards in My Bag
- Add purple "This disc was surrendered to you" banner on disc detail page
- Add `disc_surrendered` notification type with purple styling
- Exclude `surrendered` status from active recovery queries on Profile and Found Disc screens

## Test plan
- [ ] Owner can surrender disc during active recovery (found, meetup_proposed, meetup_confirmed)
- [ ] Surrendered discs show purple badge in My Bag
- [ ] Surrendered disc detail page shows purple banner
- [ ] Finder sees "Disc Received!" message and "View in My Collection" button
- [ ] Surrendered recoveries don't appear in active recovery lists
- [ ] disc_surrendered notifications display correctly

**Note:** This replaces PR #55 which had complex rebase conflicts. Created fresh from main with all the surrender functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)