### PR TITLE
feat: add forgot password and reset password flows

### DIFF
--- a/__tests__/auth/forgot-password.test.tsx
+++ b/__tests__/auth/forgot-password.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import ForgotPassword from '../../app/(auth)/forgot-password';
+import { supabase } from '../../lib/supabase';
+
+// Mock expo-router
+jest.mock('expo-router', () => ({
+  router: {
+    back: jest.fn(),
+  },
+  Link: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Mock supabase
+jest.mock('../../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      resetPasswordForEmail: jest.fn(),
+    },
+  },
+}));
+
+// Mock Alert
+jest.spyOn(Alert, 'alert');
+
+describe('ForgotPassword', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const { getByText, getByPlaceholderText } = render(<ForgotPassword />);
+
+    expect(getByText('Reset Password')).toBeTruthy();
+    expect(
+      getByText("Enter your email and we'll send you a link to reset your password.")
+    ).toBeTruthy();
+    expect(getByPlaceholderText('Enter your email')).toBeTruthy();
+    expect(getByText('Send Reset Link')).toBeTruthy();
+  });
+
+  it('shows validation error for empty email', async () => {
+    const { getByText } = render(<ForgotPassword />);
+
+    fireEvent.press(getByText('Send Reset Link'));
+
+    await waitFor(() => {
+      expect(getByText('Email is required')).toBeTruthy();
+    });
+  });
+
+  it('shows validation error for invalid email format', async () => {
+    const { getByText, getByPlaceholderText } = render(<ForgotPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter your email'), 'invalid-email');
+    fireEvent.press(getByText('Send Reset Link'));
+
+    await waitFor(() => {
+      expect(getByText('Please enter a valid email address')).toBeTruthy();
+    });
+  });
+
+  it('calls resetPasswordForEmail with correct email', async () => {
+    (supabase.auth.resetPasswordForEmail as jest.Mock).mockResolvedValue({
+      data: {},
+      error: null,
+    });
+
+    const { getByText, getByPlaceholderText } = render(<ForgotPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter your email'), 'test@example.com');
+    fireEvent.press(getByText('Send Reset Link'));
+
+    await waitFor(() => {
+      expect(supabase.auth.resetPasswordForEmail).toHaveBeenCalledWith(
+        'test@example.com',
+        expect.objectContaining({
+          redirectTo: expect.any(String),
+        })
+      );
+    });
+  });
+
+  it('shows success message after sending reset link', async () => {
+    (supabase.auth.resetPasswordForEmail as jest.Mock).mockResolvedValue({
+      data: {},
+      error: null,
+    });
+
+    const { getByText, getByPlaceholderText } = render(<ForgotPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter your email'), 'test@example.com');
+    fireEvent.press(getByText('Send Reset Link'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Check Your Email',
+        expect.stringContaining('test@example.com'),
+        expect.any(Array)
+      );
+    });
+  });
+
+  it('shows error message when resetPasswordForEmail fails', async () => {
+    (supabase.auth.resetPasswordForEmail as jest.Mock).mockResolvedValue({
+      data: null,
+      error: { message: 'User not found' },
+    });
+
+    const { getByText, getByPlaceholderText } = render(<ForgotPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter your email'), 'test@example.com');
+    fireEvent.press(getByText('Send Reset Link'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Error', 'User not found');
+    });
+  });
+
+  it('disables button while loading', async () => {
+    let resolvePromise: (value: unknown) => void;
+    const promise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+    (supabase.auth.resetPasswordForEmail as jest.Mock).mockReturnValue(promise);
+
+    const { getByText, getByPlaceholderText, getByTestId } = render(<ForgotPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter your email'), 'test@example.com');
+    fireEvent.press(getByText('Send Reset Link'));
+
+    // Button should show loading state
+    await waitFor(() => {
+      expect(getByTestId('loading-indicator')).toBeTruthy();
+    });
+
+    // Resolve the promise
+    resolvePromise!({ data: {}, error: null });
+  });
+
+  it('has a back to sign in link', () => {
+    const { getByText } = render(<ForgotPassword />);
+
+    expect(getByText('Back to Sign In')).toBeTruthy();
+  });
+});

--- a/__tests__/auth/reset-password.test.tsx
+++ b/__tests__/auth/reset-password.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import ResetPassword from '../../app/(auth)/reset-password';
+import { supabase } from '../../lib/supabase';
+
+// Mock expo-router
+jest.mock('expo-router', () => ({
+  router: {
+    replace: jest.fn(),
+  },
+}));
+
+// Mock supabase
+jest.mock('../../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      updateUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock Alert
+jest.spyOn(Alert, 'alert');
+
+describe('ResetPassword', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const { getByText, getByPlaceholderText } = render(<ResetPassword />);
+
+    expect(getByText('Create New Password')).toBeTruthy();
+    expect(getByText('Enter your new password below.')).toBeTruthy();
+    expect(getByPlaceholderText('Enter new password')).toBeTruthy();
+    expect(getByPlaceholderText('Confirm new password')).toBeTruthy();
+    expect(getByText('Reset Password')).toBeTruthy();
+  });
+
+  it('shows validation error for empty password', async () => {
+    const { getByText } = render(<ResetPassword />);
+
+    fireEvent.press(getByText('Reset Password'));
+
+    await waitFor(() => {
+      expect(getByText('Password is required')).toBeTruthy();
+    });
+  });
+
+  it('shows validation error for short password', async () => {
+    const { getByText, getByPlaceholderText } = render(<ResetPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter new password'), '12345');
+    fireEvent.press(getByText('Reset Password'));
+
+    await waitFor(() => {
+      expect(getByText('Password must be at least 6 characters')).toBeTruthy();
+    });
+  });
+
+  it('shows validation error for mismatched passwords', async () => {
+    const { getByText, getByPlaceholderText } = render(<ResetPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter new password'), 'password123');
+    fireEvent.changeText(getByPlaceholderText('Confirm new password'), 'different123');
+    fireEvent.press(getByText('Reset Password'));
+
+    await waitFor(() => {
+      expect(getByText('Passwords do not match')).toBeTruthy();
+    });
+  });
+
+  it('calls updateUser with correct password', async () => {
+    (supabase.auth.updateUser as jest.Mock).mockResolvedValue({
+      data: { user: {} },
+      error: null,
+    });
+
+    const { getByText, getByPlaceholderText } = render(<ResetPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter new password'), 'newpassword123');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm new password'),
+      'newpassword123'
+    );
+    fireEvent.press(getByText('Reset Password'));
+
+    await waitFor(() => {
+      expect(supabase.auth.updateUser).toHaveBeenCalledWith({
+        password: 'newpassword123',
+      });
+    });
+  });
+
+  it('shows success message and redirects after password reset', async () => {
+    const { router } = jest.requireMock('expo-router');
+    (supabase.auth.updateUser as jest.Mock).mockResolvedValue({
+      data: { user: {} },
+      error: null,
+    });
+
+    const { getByText, getByPlaceholderText } = render(<ResetPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter new password'), 'newpassword123');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm new password'),
+      'newpassword123'
+    );
+    fireEvent.press(getByText('Reset Password'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Password Updated',
+        'Your password has been successfully updated.',
+        expect.any(Array)
+      );
+    });
+  });
+
+  it('shows error message when updateUser fails', async () => {
+    (supabase.auth.updateUser as jest.Mock).mockResolvedValue({
+      data: null,
+      error: { message: 'Invalid session' },
+    });
+
+    const { getByText, getByPlaceholderText } = render(<ResetPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter new password'), 'newpassword123');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm new password'),
+      'newpassword123'
+    );
+    fireEvent.press(getByText('Reset Password'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Invalid session');
+    });
+  });
+
+  it('disables button while loading', async () => {
+    let resolvePromise: (value: unknown) => void;
+    const promise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+    (supabase.auth.updateUser as jest.Mock).mockReturnValue(promise);
+
+    const { getByText, getByPlaceholderText, getByTestId } = render(<ResetPassword />);
+
+    fireEvent.changeText(getByPlaceholderText('Enter new password'), 'newpassword123');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm new password'),
+      'newpassword123'
+    );
+    fireEvent.press(getByText('Reset Password'));
+
+    await waitFor(() => {
+      expect(getByTestId('loading-indicator')).toBeTruthy();
+    });
+
+    resolvePromise!({ data: { user: {} }, error: null });
+  });
+});

--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -1,0 +1,216 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { Link, router } from 'expo-router';
+import { supabase } from '@/lib/supabase';
+import Colors from '@/constants/Colors';
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const validateEmail = (emailToValidate: string): string => {
+    if (!emailToValidate.trim()) {
+      return 'Email is required';
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(emailToValidate)) {
+      return 'Please enter a valid email address';
+    }
+    return '';
+  };
+
+  const handleResetPassword = async () => {
+    const validationError = validateEmail(email);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const { error: resetError } = await supabase.auth.resetPasswordForEmail(
+        email.trim(),
+        {
+          redirectTo: 'com.aceback.app://reset-password',
+        }
+      );
+
+      if (resetError) {
+        Alert.alert('Error', resetError.message);
+      } else {
+        Alert.alert(
+          'Check Your Email',
+          `We've sent a password reset link to ${email.trim()}. ` +
+            'Please check your inbox and follow the instructions.',
+          [
+            {
+              text: 'OK',
+              onPress: () => router.back(),
+            },
+          ]
+        );
+      }
+    } catch (err) {
+      Alert.alert('Error', 'An unexpected error occurred. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      style={styles.container}
+    >
+      <View style={styles.content}>
+        <View style={styles.logoContainer}>
+          <Text style={styles.logo}>AceBack</Text>
+        </View>
+
+        <Text style={styles.title}>Reset Password</Text>
+        <Text style={styles.subtitle}>
+          Enter your email and we'll send you a link to reset your password.
+        </Text>
+
+        <View style={styles.form}>
+          <View style={styles.inputContainer}>
+            <Text style={styles.label}>Email</Text>
+            <TextInput
+              style={[styles.input, error ? styles.inputError : null]}
+              placeholder="Enter your email"
+              value={email}
+              onChangeText={(text) => {
+                setEmail(text);
+                if (error) {
+                  setError('');
+                }
+              }}
+              autoCapitalize="none"
+              keyboardType="email-address"
+              editable={!loading}
+            />
+            {error ? <Text style={styles.errorText}>{error}</Text> : null}
+          </View>
+
+          <TouchableOpacity
+            style={[styles.button, loading && styles.buttonDisabled]}
+            onPress={handleResetPassword}
+            disabled={loading}
+          >
+            {loading ? (
+              <ActivityIndicator testID="loading-indicator" color="#fff" />
+            ) : (
+              <Text style={styles.buttonText}>Send Reset Link</Text>
+            )}
+          </TouchableOpacity>
+
+          <View style={styles.footer}>
+            <Link href="/(auth)/sign-in" asChild>
+              <TouchableOpacity disabled={loading}>
+                <Text style={styles.link}>Back to Sign In</Text>
+              </TouchableOpacity>
+            </Link>
+          </View>
+        </View>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+  },
+  logoContainer: {
+    alignItems: 'center',
+    marginBottom: 48,
+  },
+  logo: {
+    fontSize: 48,
+    fontWeight: 'bold',
+    color: Colors.violet.primary,
+    letterSpacing: -1,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: '#000',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#666',
+    marginBottom: 32,
+    lineHeight: 22,
+  },
+  form: {
+    gap: 16,
+  },
+  inputContainer: {
+    gap: 8,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#000',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    backgroundColor: '#fff',
+    color: '#000',
+  },
+  inputError: {
+    borderColor: '#ef4444',
+  },
+  errorText: {
+    color: '#ef4444',
+    fontSize: 12,
+  },
+  button: {
+    backgroundColor: Colors.violet.primary,
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  footer: {
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  link: {
+    color: Colors.violet.primary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/app/(auth)/reset-password.tsx
+++ b/app/(auth)/reset-password.tsx
@@ -1,0 +1,223 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { router } from 'expo-router';
+import { supabase } from '@/lib/supabase';
+import Colors from '@/constants/Colors';
+
+export default function ResetPassword() {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState<{
+    password?: string;
+    confirmPassword?: string;
+  }>({});
+
+  const validateForm = (): boolean => {
+    const newErrors: { password?: string; confirmPassword?: string } = {};
+
+    if (!password.trim()) {
+      newErrors.password = 'Password is required';
+    } else if (password.length < 6) {
+      newErrors.password = 'Password must be at least 6 characters';
+    }
+
+    if (password && confirmPassword && password !== confirmPassword) {
+      newErrors.confirmPassword = 'Passwords do not match';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleResetPassword = async () => {
+    if (!validateForm()) {
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const { error } = await supabase.auth.updateUser({
+        password: password,
+      });
+
+      if (error) {
+        Alert.alert('Error', error.message);
+      } else {
+        Alert.alert(
+          'Password Updated',
+          'Your password has been successfully updated.',
+          [
+            {
+              text: 'OK',
+              onPress: () => router.replace('/(tabs)'),
+            },
+          ]
+        );
+      }
+    } catch (err) {
+      Alert.alert('Error', 'An unexpected error occurred. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      style={styles.container}
+    >
+      <View style={styles.content}>
+        <View style={styles.logoContainer}>
+          <Text style={styles.logo}>AceBack</Text>
+        </View>
+
+        <Text style={styles.title}>Create New Password</Text>
+        <Text style={styles.subtitle}>Enter your new password below.</Text>
+
+        <View style={styles.form}>
+          <View style={styles.inputContainer}>
+            <Text style={styles.label}>New Password</Text>
+            <TextInput
+              style={[styles.input, errors.password ? styles.inputError : null]}
+              placeholder="Enter new password"
+              value={password}
+              onChangeText={(text) => {
+                setPassword(text);
+                if (errors.password) {
+                  setErrors({ ...errors, password: undefined });
+                }
+              }}
+              secureTextEntry
+              editable={!loading}
+            />
+            {errors.password ? (
+              <Text style={styles.errorText}>{errors.password}</Text>
+            ) : null}
+          </View>
+
+          <View style={styles.inputContainer}>
+            <Text style={styles.label}>Confirm Password</Text>
+            <TextInput
+              style={[
+                styles.input,
+                errors.confirmPassword ? styles.inputError : null,
+              ]}
+              placeholder="Confirm new password"
+              value={confirmPassword}
+              onChangeText={(text) => {
+                setConfirmPassword(text);
+                if (errors.confirmPassword) {
+                  setErrors({ ...errors, confirmPassword: undefined });
+                }
+              }}
+              secureTextEntry
+              editable={!loading}
+            />
+            {errors.confirmPassword ? (
+              <Text style={styles.errorText}>{errors.confirmPassword}</Text>
+            ) : null}
+          </View>
+
+          <TouchableOpacity
+            style={[styles.button, loading && styles.buttonDisabled]}
+            onPress={handleResetPassword}
+            disabled={loading}
+          >
+            {loading ? (
+              <ActivityIndicator testID="loading-indicator" color="#fff" />
+            ) : (
+              <Text style={styles.buttonText}>Reset Password</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+  },
+  logoContainer: {
+    alignItems: 'center',
+    marginBottom: 48,
+  },
+  logo: {
+    fontSize: 48,
+    fontWeight: 'bold',
+    color: Colors.violet.primary,
+    letterSpacing: -1,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: '#000',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#666',
+    marginBottom: 32,
+  },
+  form: {
+    gap: 16,
+  },
+  inputContainer: {
+    gap: 8,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#000',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    backgroundColor: '#fff',
+    color: '#000',
+  },
+  inputError: {
+    borderColor: '#ef4444',
+  },
+  errorText: {
+    color: '#ef4444',
+    fontSize: 12,
+  },
+  button: {
+    backgroundColor: Colors.violet.primary,
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -146,6 +146,12 @@ export default function SignIn() {
             )}
           </View>
 
+          <Link href="/(auth)/forgot-password" asChild>
+            <TouchableOpacity disabled={loading} style={styles.forgotPassword}>
+              <Text style={styles.forgotPasswordText}>Forgot password?</Text>
+            </TouchableOpacity>
+          </Link>
+
           <TouchableOpacity
             style={[styles.button, loading && styles.buttonDisabled]}
             onPress={handleSignIn}
@@ -272,6 +278,16 @@ const styles = StyleSheet.create({
     color: '#000',
     fontSize: 16,
     fontWeight: '600',
+  },
+  forgotPassword: {
+    alignSelf: 'flex-end',
+    marginTop: -8,
+    marginBottom: 8,
+  },
+  forgotPasswordText: {
+    color: Colors.violet.primary,
+    fontSize: 14,
+    fontWeight: '500',
   },
   footer: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
Add password reset functionality allowing users to recover their accounts.

## Changes
- Add forgot-password screen with email input and validation
- Add reset-password screen for setting new password after deep link
- Add "Forgot password?" link on sign-in screen
- Full test coverage with TDD (16 tests)

## User Flow
1. User taps "Forgot password?" on sign-in screen
2. User enters email address
3. Supabase sends password reset email
4. User clicks link in email, opens app
5. User enters new password
6. Password is updated, user is redirected to app

## Technical Details
- Uses `supabase.auth.resetPasswordForEmail()` for email
- Uses `supabase.auth.updateUser()` for password change
- Deep link: `com.aceback.app://reset-password`

## Test Plan
- [x] 8 tests for forgot-password screen
- [x] 8 tests for reset-password screen
- [x] Email validation
- [x] Password validation (length, match)
- [x] Error handling
- [x] Loading states

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)