### PR TITLE
feat: add caching for My Bag page discs

### DIFF
--- a/__tests__/utils/discCache.test.ts
+++ b/__tests__/utils/discCache.test.ts
@@ -1,0 +1,102 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getCachedDiscs,
+  setCachedDiscs,
+  clearDiscCache,
+  DISC_CACHE_KEY,
+} from '../../utils/discCache';
+
+// AsyncStorage is already mocked in jest.setup.js
+
+describe('discCache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCachedDiscs', () => {
+    it('returns null when cache is empty', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+      const result = await getCachedDiscs();
+
+      expect(result).toBeNull();
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(DISC_CACHE_KEY);
+    });
+
+    it('returns parsed discs when cache exists', async () => {
+      const mockDiscs = [
+        { id: '1', mold: 'Destroyer' },
+        { id: '2', mold: 'Buzzz' },
+      ];
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(mockDiscs)
+      );
+
+      const result = await getCachedDiscs();
+
+      expect(result).toEqual(mockDiscs);
+    });
+
+    it('returns null when JSON parsing fails', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue('invalid json');
+
+      const result = await getCachedDiscs();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when AsyncStorage throws', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValue(
+        new Error('Storage error')
+      );
+
+      const result = await getCachedDiscs();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setCachedDiscs', () => {
+    it('stores discs as JSON string', async () => {
+      const mockDiscs = [
+        { id: '1', mold: 'Destroyer' },
+        { id: '2', mold: 'Buzzz' },
+      ];
+
+      await setCachedDiscs(mockDiscs);
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        DISC_CACHE_KEY,
+        JSON.stringify(mockDiscs)
+      );
+    });
+
+    it('handles AsyncStorage errors gracefully', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValue(
+        new Error('Storage error')
+      );
+
+      // Should not throw
+      await expect(
+        setCachedDiscs([{ id: '1', mold: 'Test' }])
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('clearDiscCache', () => {
+    it('removes disc cache from storage', async () => {
+      await clearDiscCache();
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(DISC_CACHE_KEY);
+    });
+
+    it('handles AsyncStorage errors gracefully', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValue(
+        new Error('Storage error')
+      );
+
+      // Should not throw
+      await expect(clearDiscCache()).resolves.not.toThrow();
+    });
+  });
+});

--- a/utils/discCache.ts
+++ b/utils/discCache.ts
@@ -1,0 +1,76 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const DISC_CACHE_KEY = '@aceback/discs_cache';
+
+export interface CachedDisc {
+  id: string;
+  mold?: string;
+  name?: string;
+  manufacturer?: string;
+  plastic?: string;
+  weight?: number;
+  color?: string;
+  flight_numbers?: {
+    speed: number | null;
+    glide: number | null;
+    turn: number | null;
+    fade: number | null;
+  };
+  reward_amount?: string;
+  notes?: string;
+  created_at?: string;
+  photos?: Array<{
+    id: string;
+    storage_path: string;
+    photo_uuid: string;
+    photo_url?: string;
+    created_at: string;
+  }>;
+  active_recovery?: {
+    id: string;
+    status: string;
+    finder_id: string;
+    found_at: string;
+  } | null;
+  was_surrendered?: boolean;
+  surrendered_at?: string | null;
+}
+
+/**
+ * Get cached discs from AsyncStorage
+ * Returns null if cache is empty or invalid
+ */
+export async function getCachedDiscs(): Promise<CachedDisc[] | null> {
+  try {
+    const cached = await AsyncStorage.getItem(DISC_CACHE_KEY);
+    if (!cached) {
+      return null;
+    }
+    return JSON.parse(cached);
+  } catch (error) {
+    console.error('Error reading disc cache:', error);
+    return null;
+  }
+}
+
+/**
+ * Save discs to AsyncStorage cache
+ */
+export async function setCachedDiscs(discs: CachedDisc[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(DISC_CACHE_KEY, JSON.stringify(discs));
+  } catch (error) {
+    console.error('Error saving disc cache:', error);
+  }
+}
+
+/**
+ * Clear the disc cache
+ */
+export async function clearDiscCache(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(DISC_CACHE_KEY);
+  } catch (error) {
+    console.error('Error clearing disc cache:', error);
+  }
+}


### PR DESCRIPTION
## Summary
Add client-side caching for discs to improve My Bag page load times.

## Changes
- Add `discCache` utility with `getCachedDiscs`, `setCachedDiscs`, `clearDiscCache`
- Load cached data immediately on mount for faster perceived load
- Fetch fresh data in background and update UI seamlessly
- Only show loading spinner when no cached data exists
- Only show error alert when no cached data to display

## How It Works
1. On mount, immediately load cached discs from AsyncStorage
2. Show cached data right away (no loading spinner)
3. Fetch fresh data from API in background
4. Update UI when fresh data arrives
5. Save fresh data to cache for next time

## Test Plan
- [x] 8 tests for discCache utility
- [x] Handles empty cache
- [x] Handles JSON parse errors
- [x] Handles AsyncStorage errors gracefully

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)