### PR TITLE
fix: add cache staleness check to prevent redundant network fetches

### DIFF
--- a/__tests__/tabs/my-bag.test.tsx
+++ b/__tests__/tabs/my-bag.test.tsx
@@ -38,9 +38,11 @@ jest.mock('../../lib/supabase', () => ({
 // Mock discCache
 const mockGetCachedDiscs = jest.fn();
 const mockSetCachedDiscs = jest.fn();
+const mockIsCacheStale = jest.fn();
 jest.mock('../../utils/discCache', () => ({
   getCachedDiscs: () => mockGetCachedDiscs(),
   setCachedDiscs: (discs: any) => mockSetCachedDiscs(discs),
+  isCacheStale: () => mockIsCacheStale(),
 }));
 
 // Mock fetch
@@ -98,6 +100,7 @@ describe('MyBagScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetCachedDiscs.mockResolvedValue(null);
+    mockIsCacheStale.mockResolvedValue(true); // Default to stale so tests trigger fetch
     mockGetSession.mockResolvedValue({
       data: { session: { access_token: 'test-token' } },
     });

--- a/app/(tabs)/my-bag.tsx
+++ b/app/(tabs)/my-bag.tsx
@@ -13,7 +13,7 @@ import { Text, View } from '@/components/Themed';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import Colors from '@/constants/Colors';
 import { supabase } from '@/lib/supabase';
-import { getCachedDiscs, setCachedDiscs } from '@/utils/discCache';
+import { getCachedDiscs, setCachedDiscs, isCacheStale } from '@/utils/discCache';
 
 interface FlightNumbers {
   speed: number | null;
@@ -150,12 +150,18 @@ export default function MyBagScreen() {
     }
   };
 
-  // Only fetch on focus after cache has been checked
+  // Only fetch on focus if cache is stale
   useFocusEffect(
     useCallback(() => {
-      if (cacheLoaded) {
-        fetchDiscs();
-      }
+      const checkAndFetch = async () => {
+        if (cacheLoaded) {
+          const stale = await isCacheStale();
+          if (stale) {
+            fetchDiscs();
+          }
+        }
+      };
+      checkAndFetch();
     }, [cacheLoaded])
   );
 


### PR DESCRIPTION
## Summary

- Add timestamp tracking to disc cache with 30-second TTL
- Only refetch data on navigation if cache is stale
- Skip network requests when returning to My Bag tab within 30 seconds
- Pull-to-refresh still always fetches fresh data

## Problem

Previously, every navigation back to the My Bag tab triggered a network fetch, even if the user just left the screen moments ago. This caused unnecessary loading delays and network usage.

## Solution

Added a staleness check to the cache:
- Cache now stores a timestamp when data is saved
- `isCacheStale()` returns true if cache is older than 30 seconds
- `useFocusEffect` only fetches if cache is stale

| Action | Before | After |
|--------|--------|-------|
| My Bag → Found Disc → My Bag (< 30s) | Network fetch | Instant (cached) |
| My Bag → Found Disc → My Bag (> 30s) | Network fetch | Network fetch |
| Pull-to-refresh | Network fetch | Network fetch |

## Test plan

- [x] Unit tests pass (12 tests in discCache.test.ts)
- [x] Navigate to My Bag, go to Found Disc, return - should be instant
- [x] Pull-to-refresh still fetches fresh data

🤖 Generated with [Claude Code](https://claude.com/claude-code)