### PR TITLE
fix: improve drop-off action button spacing

### DIFF
--- a/app/recovery/[id].tsx
+++ b/app/recovery/[id].tsx
@@ -473,35 +473,37 @@ export default function RecoveryDetailScreen() {
             </RNView>
           )}
 
-          {/* Get Directions button */}
-          <Pressable
-            style={styles.directionsButton}
-            onPress={() => {
-              const url = `https://maps.google.com/?q=${recovery.drop_off!.latitude},${recovery.drop_off!.longitude}`;
-              Linking.openURL(url);
-            }}
-          >
-            <FontAwesome name="location-arrow" size={16} color="#fff" />
-            <Text style={styles.directionsButtonText}>Get Directions to Pickup</Text>
-          </Pressable>
-
-          {/* Mark as Recovered button for owner */}
-          {isOwner && (
+          {/* Action buttons */}
+          <RNView style={styles.dropOffActions}>
             <Pressable
-              style={[styles.primaryButton, { marginTop: 12 }]}
-              onPress={handleCompleteRecovery}
-              disabled={actionLoading}
+              style={styles.directionsButton}
+              onPress={() => {
+                const url = `https://maps.google.com/?q=${recovery.drop_off!.latitude},${recovery.drop_off!.longitude}`;
+                Linking.openURL(url);
+              }}
             >
-              {actionLoading ? (
-                <ActivityIndicator color="#fff" />
-              ) : (
-                <>
-                  <FontAwesome name="check" size={18} color="#fff" />
-                  <Text style={styles.primaryButtonText}>Mark as Recovered</Text>
-                </>
-              )}
+              <FontAwesome name="location-arrow" size={16} color="#fff" />
+              <Text style={styles.directionsButtonText}>Get Directions to Pickup</Text>
             </Pressable>
-          )}
+
+            {/* Mark as Recovered button for owner */}
+            {isOwner && (
+              <Pressable
+                style={styles.primaryButton}
+                onPress={handleCompleteRecovery}
+                disabled={actionLoading}
+              >
+                {actionLoading ? (
+                  <ActivityIndicator color="#fff" />
+                ) : (
+                  <>
+                    <FontAwesome name="check" size={18} color="#fff" />
+                    <Text style={styles.primaryButtonText}>Mark as Recovered</Text>
+                  </>
+                )}
+              </Pressable>
+            )}
+          </RNView>
         </RNView>
       )}
 
@@ -1147,5 +1149,10 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#444',
     lineHeight: 20,
+  },
+  dropOffActions: {
+    width: '100%',
+    gap: 12,
+    marginTop: 16,
   },
 });


### PR DESCRIPTION
## Summary
- Wrap drop-off action buttons in a container with `width: 100%`
- Add consistent 12px gap between buttons
- Add 16px top margin for spacing from location notes

## Test plan
- [ ] View recovery details for a dropped-off disc as owner
- [ ] Verify buttons are full width and evenly spaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)