### PR TITLE
feat: add abandon and claim disc UI

### DIFF
--- a/app/claim-disc.tsx
+++ b/app/claim-disc.tsx
@@ -1,0 +1,331 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Image,
+  Pressable,
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+} from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/lib/supabase';
+import Colors from '@/constants/Colors';
+
+/**
+ * Claim Disc Screen
+ *
+ * Displayed when a user scans a QR code for an abandoned disc (no owner).
+ * Allows the user to claim the disc and add it to their collection.
+ */
+export default function ClaimDiscScreen() {
+  const router = useRouter();
+  const { user } = useAuth();
+  const params = useLocalSearchParams<{
+    discId: string;
+    discName: string;
+    discManufacturer: string;
+    discMold: string;
+    discPlastic: string;
+    discColor: string;
+    discPhotoUrl: string;
+  }>();
+
+  const [claiming, setClaiming] = useState(false);
+
+  const handleClaimDisc = async () => {
+    if (!user) {
+      Alert.alert(
+        'Sign In Required',
+        'You need to sign in to claim this disc.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Sign In',
+            onPress: () => router.replace('/(auth)/sign-in'),
+          },
+        ]
+      );
+      return;
+    }
+
+    setClaiming(true);
+    try {
+      const { data: session } = await supabase.auth.getSession();
+      if (!session?.session?.access_token) {
+        throw new Error('Not authenticated');
+      }
+
+      const response = await fetch(
+        `${process.env.EXPO_PUBLIC_SUPABASE_URL}/functions/v1/claim-disc`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session.session.access_token}`,
+          },
+          body: JSON.stringify({ disc_id: params.discId }),
+        }
+      );
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to claim disc');
+      }
+
+      Alert.alert(
+        'Disc Claimed!',
+        'This disc has been added to your collection.',
+        [
+          {
+            text: 'View Disc',
+            onPress: () => router.replace(`/disc/${params.discId}`),
+          },
+        ]
+      );
+    } catch (err) {
+      console.error('Error claiming disc:', err);
+      Alert.alert(
+        'Error',
+        err instanceof Error ? err.message : 'Failed to claim disc'
+      );
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  const discName =
+    params.discName ||
+    [params.discManufacturer, params.discMold].filter(Boolean).join(' ') ||
+    'Unknown Disc';
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      {/* Header */}
+      <View style={styles.header}>
+        <Pressable style={styles.backButton} onPress={() => router.back()}>
+          <FontAwesome name="chevron-left" size={20} color={Colors.violet.primary} />
+        </Pressable>
+        <Text style={styles.headerTitle}>Claim Disc</Text>
+        <View style={styles.backButton} />
+      </View>
+
+      {/* Disc Photo */}
+      <View style={styles.photoContainer}>
+        {params.discPhotoUrl ? (
+          <Image source={{ uri: params.discPhotoUrl }} style={styles.photo} />
+        ) : (
+          <View style={styles.placeholderPhoto}>
+            <FontAwesome name="circle" size={80} color="#ccc" />
+          </View>
+        )}
+      </View>
+
+      {/* Disc Info */}
+      <View style={styles.infoCard}>
+        <Text style={styles.discName}>{discName}</Text>
+
+        {params.discManufacturer && (
+          <View style={styles.infoRow}>
+            <Text style={styles.infoLabel}>Manufacturer</Text>
+            <Text style={styles.infoValue}>{params.discManufacturer}</Text>
+          </View>
+        )}
+
+        {params.discMold && (
+          <View style={styles.infoRow}>
+            <Text style={styles.infoLabel}>Mold</Text>
+            <Text style={styles.infoValue}>{params.discMold}</Text>
+          </View>
+        )}
+
+        {params.discPlastic && (
+          <View style={styles.infoRow}>
+            <Text style={styles.infoLabel}>Plastic</Text>
+            <Text style={styles.infoValue}>{params.discPlastic}</Text>
+          </View>
+        )}
+
+        {params.discColor && (
+          <View style={styles.infoRow}>
+            <Text style={styles.infoLabel}>Color</Text>
+            <Text style={styles.infoValue}>{params.discColor}</Text>
+          </View>
+        )}
+      </View>
+
+      {/* Available to Claim Banner */}
+      <View style={styles.claimBanner}>
+        <FontAwesome name="gift" size={24} color={Colors.violet.primary} />
+        <View style={styles.claimBannerText}>
+          <Text style={styles.claimBannerTitle}>Available to Claim!</Text>
+          <Text style={styles.claimBannerSubtitle}>
+            This disc has been abandoned by its previous owner. You can claim it
+            and add it to your collection.
+          </Text>
+        </View>
+      </View>
+
+      {/* Claim Button */}
+      <Pressable
+        style={[styles.claimButton, claiming && styles.buttonDisabled]}
+        onPress={handleClaimDisc}
+        disabled={claiming}
+      >
+        {claiming ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <>
+            <FontAwesome name="plus-circle" size={20} color="#fff" />
+            <Text style={styles.claimButtonText}>Claim This Disc</Text>
+          </>
+        )}
+      </Pressable>
+
+      {/* Skip Link */}
+      <Pressable style={styles.skipButton} onPress={() => router.replace('/(tabs)')}>
+        <Text style={styles.skipButtonText}>No thanks, go to home</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  content: {
+    paddingBottom: 40,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 60,
+    paddingBottom: 16,
+    backgroundColor: '#fff',
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#333',
+  },
+  photoContainer: {
+    alignItems: 'center',
+    paddingVertical: 24,
+    backgroundColor: '#fff',
+  },
+  photo: {
+    width: 200,
+    height: 200,
+    borderRadius: 100,
+    backgroundColor: '#f0f0f0',
+  },
+  placeholderPhoto: {
+    width: 200,
+    height: 200,
+    borderRadius: 100,
+    backgroundColor: '#f0f0f0',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  infoCard: {
+    backgroundColor: '#fff',
+    marginHorizontal: 16,
+    marginTop: 16,
+    borderRadius: 12,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  discName: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#333',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  infoRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f0f0f0',
+  },
+  infoLabel: {
+    fontSize: 14,
+    color: '#666',
+  },
+  infoValue: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#333',
+  },
+  claimBanner: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: Colors.violet.light,
+    marginHorizontal: 16,
+    marginTop: 16,
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+  },
+  claimBannerText: {
+    flex: 1,
+  },
+  claimBannerTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: Colors.violet.primary,
+    marginBottom: 4,
+  },
+  claimBannerSubtitle: {
+    fontSize: 14,
+    color: '#666',
+    lineHeight: 20,
+  },
+  claimButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.violet.primary,
+    marginHorizontal: 16,
+    marginTop: 24,
+    paddingVertical: 16,
+    borderRadius: 12,
+    gap: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  claimButtonText: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#fff',
+  },
+  skipButton: {
+    alignItems: 'center',
+    paddingVertical: 16,
+    marginTop: 8,
+  },
+  skipButtonText: {
+    fontSize: 14,
+    color: '#666',
+  },
+});

--- a/app/d/[code].tsx
+++ b/app/d/[code].tsx
@@ -12,6 +12,7 @@ import Colors from '@/constants/Colors';
  * This route handles incoming QR code scans from the native camera.
  * It looks up the disc and redirects appropriately:
  * - If user owns the disc: redirect to disc detail page
+ * - If disc is claimable (abandoned): redirect to claim page
  * - If user doesn't own disc: redirect to found-disc tab with the code pre-filled
  */
 export default function DeepLinkHandler() {
@@ -56,6 +57,23 @@ export default function DeepLinkHandler() {
       // If user owns this disc, go to detail page
       if (data.is_owner) {
         router.replace(`/disc/${data.disc.id}`);
+        return;
+      }
+
+      // If disc is claimable (abandoned with no owner), go to claim page
+      if (data.is_claimable) {
+        router.replace({
+          pathname: '/claim-disc',
+          params: {
+            discId: data.disc.id,
+            discName: data.disc.name || '',
+            discManufacturer: data.disc.manufacturer || '',
+            discMold: data.disc.mold || '',
+            discPlastic: data.disc.plastic || '',
+            discColor: data.disc.color || '',
+            discPhotoUrl: data.disc.photo_url || '',
+          },
+        });
         return;
       }
 


### PR DESCRIPTION
## Summary
- Add "Abandon Disc" button to recovery details when status is `dropped_off`
- Update QR deep link handler to redirect to claim page for ownerless discs
- Create new `claim-disc` screen for users to claim abandoned discs

## How It Works
1. Owner views a `dropped_off` recovery and sees "Abandon Disc" button
2. Confirming abandonment calls the API and redirects home
3. When someone scans an abandoned disc's QR code:
   - App detects `is_claimable: true` from API
   - Redirects to claim-disc screen showing disc info
   - User can claim the disc, adding it to their collection

## Test plan
- [ ] Verify Abandon button appears for owner on dropped_off recoveries
- [ ] Test abandon flow redirects home after success
- [ ] Test scanning abandoned disc QR shows claim page
- [ ] Test claiming disc adds it to user's collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)