### PR TITLE
chore: remove unused deferred linking functions

### DIFF
--- a/__tests__/lib/deferredLinking.test.ts
+++ b/__tests__/lib/deferredLinking.test.ts
@@ -1,28 +1,14 @@
 import * as Clipboard from 'expo-clipboard';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import {
   isValidAceBackCode,
   checkClipboardForCode,
-  hasCheckedDeferredCode,
-  markDeferredCodeChecked,
-  storeDeferredCode,
-  getAndClearDeferredCode,
-  clearDeferredLinkingState,
 } from '@/lib/deferredLinking';
 
 // Mock expo-clipboard
 jest.mock('expo-clipboard', () => ({
   hasStringAsync: jest.fn(),
   getStringAsync: jest.fn(),
-}));
-
-// Mock AsyncStorage
-jest.mock('@react-native-async-storage/async-storage', () => ({
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-  multiRemove: jest.fn(),
 }));
 
 describe('deferredLinking', () => {
@@ -142,126 +128,6 @@ describe('deferredLinking', () => {
       const result = await checkClipboardForCode();
 
       expect(result).toBeNull();
-    });
-  });
-
-  describe('hasCheckedDeferredCode', () => {
-    it('returns false when not checked yet', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-
-      const result = await hasCheckedDeferredCode();
-
-      expect(result).toBe(false);
-      expect(AsyncStorage.getItem).toHaveBeenCalledWith(
-        'aceback_deferred_code_checked'
-      );
-    });
-
-    it('returns true when already checked', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue('true');
-
-      const result = await hasCheckedDeferredCode();
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false on storage error', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockRejectedValue(
-        new Error('Storage error')
-      );
-
-      const result = await hasCheckedDeferredCode();
-
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('markDeferredCodeChecked', () => {
-    it('sets checked flag in storage', async () => {
-      await markDeferredCodeChecked();
-
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-        'aceback_deferred_code_checked',
-        'true'
-      );
-    });
-
-    it('does not throw on storage error', async () => {
-      (AsyncStorage.setItem as jest.Mock).mockRejectedValue(
-        new Error('Storage error')
-      );
-
-      await expect(markDeferredCodeChecked()).resolves.not.toThrow();
-    });
-  });
-
-  describe('storeDeferredCode', () => {
-    it('stores uppercase code in storage', async () => {
-      await storeDeferredCode('abc123');
-
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-        'aceback_deferred_code',
-        'ABC123'
-      );
-    });
-
-    it('does not throw on storage error', async () => {
-      (AsyncStorage.setItem as jest.Mock).mockRejectedValue(
-        new Error('Storage error')
-      );
-
-      await expect(storeDeferredCode('ABC123')).resolves.not.toThrow();
-    });
-  });
-
-  describe('getAndClearDeferredCode', () => {
-    it('returns stored code and clears it', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue('ABC123');
-
-      const result = await getAndClearDeferredCode();
-
-      expect(result).toBe('ABC123');
-      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
-        'aceback_deferred_code'
-      );
-    });
-
-    it('returns null when no code stored', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-
-      const result = await getAndClearDeferredCode();
-
-      expect(result).toBeNull();
-      expect(AsyncStorage.removeItem).not.toHaveBeenCalled();
-    });
-
-    it('returns null on storage error', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockRejectedValue(
-        new Error('Storage error')
-      );
-
-      const result = await getAndClearDeferredCode();
-
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('clearDeferredLinkingState', () => {
-    it('removes all deferred linking keys from storage', async () => {
-      await clearDeferredLinkingState();
-
-      expect(AsyncStorage.multiRemove).toHaveBeenCalledWith([
-        'aceback_deferred_code',
-        'aceback_deferred_code_checked',
-      ]);
-    });
-
-    it('does not throw on storage error', async () => {
-      (AsyncStorage.multiRemove as jest.Mock).mockRejectedValue(
-        new Error('Storage error')
-      );
-
-      await expect(clearDeferredLinkingState()).resolves.not.toThrow();
     });
   });
 });

--- a/lib/deferredLinking.ts
+++ b/lib/deferredLinking.ts
@@ -1,8 +1,4 @@
 import * as Clipboard from 'expo-clipboard';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-
-const DEFERRED_CODE_KEY = 'aceback_deferred_code';
-const DEFERRED_CODE_CHECKED_KEY = 'aceback_deferred_code_checked';
 
 // AceBack QR codes are 6-8 alphanumeric characters
 const CODE_PATTERN = /^[A-Z0-9]{6,8}$/;
@@ -44,65 +40,5 @@ export async function checkClipboardForCode(): Promise<string | null> {
     return null;
   } catch {
     return null;
-  }
-}
-
-/**
- * Check if we've already prompted for a deferred code this session
- */
-export async function hasCheckedDeferredCode(): Promise<boolean> {
-  try {
-    const checked = await AsyncStorage.getItem(DEFERRED_CODE_CHECKED_KEY);
-    return checked === 'true';
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Mark that we've checked for deferred codes this session
- */
-export async function markDeferredCodeChecked(): Promise<void> {
-  try {
-    await AsyncStorage.setItem(DEFERRED_CODE_CHECKED_KEY, 'true');
-  } catch {
-    // Ignore storage errors
-  }
-}
-
-/**
- * Store a deferred code for later processing
- */
-export async function storeDeferredCode(code: string): Promise<void> {
-  try {
-    await AsyncStorage.setItem(DEFERRED_CODE_KEY, code.toUpperCase());
-  } catch {
-    // Ignore storage errors
-  }
-}
-
-/**
- * Get and clear a stored deferred code
- */
-export async function getAndClearDeferredCode(): Promise<string | null> {
-  try {
-    const code = await AsyncStorage.getItem(DEFERRED_CODE_KEY);
-    if (code) {
-      await AsyncStorage.removeItem(DEFERRED_CODE_KEY);
-    }
-    return code;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Clear all deferred linking state (for testing/logout)
- */
-export async function clearDeferredLinkingState(): Promise<void> {
-  try {
-    await AsyncStorage.multiRemove([DEFERRED_CODE_KEY, DEFERRED_CODE_CHECKED_KEY]);
-  } catch {
-    // Ignore storage errors
   }
 }


### PR DESCRIPTION
## Summary

- Remove unused AsyncStorage-based deferred linking functions
- Update tests to match current in-memory implementation

## Changes

Since we switched to in-memory session tracking, these functions are no longer used:
- `hasCheckedDeferredCode`
- `markDeferredCodeChecked`
- `storeDeferredCode`
- `getAndClearDeferredCode`
- `clearDeferredLinkingState`

**Files changed:**
- `lib/deferredLinking.ts` - Removed 5 unused functions, AsyncStorage import
- `__tests__/lib/deferredLinking.test.ts` - Removed tests for deleted functions
- `__tests__/hooks/useDeferredLinking.test.tsx` - Updated to test in-memory implementation

## Test plan

- [x] All 399 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)