### PR TITLE
feat: add expo-image caching for profile photos

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Image, View, Text, StyleSheet, ViewStyle } from 'react-native';
+import { View, Text, StyleSheet, ViewStyle } from 'react-native';
+import { Image } from 'expo-image';
 import Colors from '@/constants/Colors';
 
 interface AvatarProps {
@@ -15,6 +16,7 @@ interface AvatarProps {
 
 /**
  * Avatar component that displays a user's profile picture.
+ * Uses expo-image for memory and disk caching.
  * Falls back to initials if the image fails to load or is not provided.
  */
 export function Avatar({ avatarUrl, name, size = 40, style }: AvatarProps) {
@@ -52,6 +54,8 @@ export function Avatar({ avatarUrl, name, size = 40, style }: AvatarProps) {
         source={{ uri: avatarUrl }}
         style={[styles.image, containerStyle, style]}
         onError={() => setImageError(true)}
+        cachePolicy="memory-disk"
+        transition={200}
       />
     );
   }

--- a/components/__tests__/Avatar.test.tsx
+++ b/components/__tests__/Avatar.test.tsx
@@ -19,8 +19,8 @@ describe('Avatar', () => {
         <Avatar avatarUrl="https://example.com/bad-url.jpg" name="John Doe" />
       );
 
-      // Find the Image component and trigger error
-      const Image = require('react-native').Image;
+      // Find the expo-image Image component and trigger error
+      const { Image } = require('expo-image');
       const image = UNSAFE_getByType(Image);
       fireEvent(image, 'error');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "expo-crypto": "~15.0.7",
         "expo-device": "~8.0.10",
         "expo-font": "~14.0.9",
+        "expo-image": "~3.0.11",
         "expo-image-manipulator": "^14.0.7",
         "expo-image-picker": "~17.0.10",
         "expo-linking": "~8.0.9",
@@ -5635,6 +5636,23 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-image": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-3.0.11.tgz",
+      "integrity": "sha512-4TudfUCLgYgENv+f48omnU8tjS2S0Pd9EaON5/s1ZUBRwZ7K8acEr4NfvLPSaeXvxW24iLAiyQ7sV7BXQH3RoA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-image-loader": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "expo-crypto": "~15.0.7",
     "expo-device": "~8.0.10",
     "expo-font": "~14.0.9",
+    "expo-image": "~3.0.11",
     "expo-image-manipulator": "^14.0.7",
     "expo-image-picker": "~17.0.10",
     "expo-linking": "~8.0.9",


### PR DESCRIPTION
## Summary
- Add expo-image for avatar caching (memory + disk)
- Improves performance for subsequent avatar loads

## Changes
- Install `expo-image` package
- Update `Avatar` component to use `expo-image` instead of `react-native Image`
- Enable `cachePolicy="memory-disk"` for optimal caching
- Add smooth 200ms transition on image load
- Update Avatar tests to use expo-image

## Test plan
- [ ] Verify avatars load correctly
- [ ] Verify avatars cache properly (fast reload on navigation)
- [ ] Verify fallback to initials still works on image error

## Dependencies
- Depends on acebackapp/api#108 for profile photo upload/delete API

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)