### PR TITLE
fix: improve order UI styling and spacing

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -11,7 +11,7 @@ export default function HomeScreen() {
 
   return (
     <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
-      <View style={styles.container}>
+      <RNView style={styles.container}>
         <Text style={styles.title}>Welcome to AceBack!</Text>
         {user && <Text style={styles.email}>{user.email}</Text>}
         <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
@@ -19,7 +19,7 @@ export default function HomeScreen() {
           Never lose your favorite disc again. Track your collection and help others find their lost
           discs.
         </Text>
-      </View>
+      </RNView>
 
       {/* Order Stickers CTA Card */}
       <Pressable style={styles.stickerCard} onPress={() => router.push('/order-stickers')}>
@@ -74,6 +74,7 @@ export default function HomeScreen() {
 const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
+    backgroundColor: '#fff',
   },
   scrollContent: {
     padding: 20,

--- a/app/order-stickers.tsx
+++ b/app/order-stickers.tsx
@@ -288,7 +288,7 @@ export default function OrderStickersScreen() {
           </RNView>
 
           {/* Spacer for button */}
-          <RNView style={{ height: 100 }} />
+          <RNView style={{ height: 120 }} />
         </ScrollView>
 
         {/* Checkout Button */}
@@ -321,9 +321,11 @@ export default function OrderStickersScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: '#fff',
   },
   scrollView: {
     flex: 1,
+    backgroundColor: '#fff',
   },
   content: {
     padding: 16,


### PR DESCRIPTION
## Changes

- Fix home page grey background, use white instead
- Remove white square around welcome text by using RNView
- Add white background to order stickers page
- Increase bottom spacing on order form (100px -> 120px)

## Testing

Test by running the app and verifying:
- Home page has solid white background
- No white square around "Welcome to AceBack" text
- Order stickers page has white background
- Adequate spacing when scrolling to bottom of order form

🤖 Generated with [Claude Code](https://claude.com/claude-code)