### PR TITLE
feat: add checkout success and cancel screens for deep linking

### DIFF
--- a/app/checkout/cancel.tsx
+++ b/app/checkout/cancel.tsx
@@ -1,0 +1,77 @@
+import { useEffect } from 'react';
+import { View as RNView, StyleSheet } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { Text } from '@/components/Themed';
+
+export default function CheckoutCancelScreen() {
+  const { order_id } = useLocalSearchParams<{ order_id?: string }>();
+
+  useEffect(() => {
+    // Navigate back to home after 2 seconds
+    const timer = setTimeout(() => {
+      router.replace('/(tabs)');
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <RNView style={styles.container}>
+      <RNView style={styles.content}>
+        <Text style={styles.emoji}>❌</Text>
+        <Text style={styles.title}>Payment Cancelled</Text>
+        <Text style={styles.message}>
+          Your payment was cancelled. No charges were made.
+        </Text>
+        {order_id && (
+          <Text style={styles.orderId}>Order ID: {order_id}</Text>
+        )}
+        <Text style={styles.redirect}>
+          Returning to the app...
+        </Text>
+      </RNView>
+    </RNView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    alignItems: 'center',
+    padding: 20,
+  },
+  emoji: {
+    fontSize: 64,
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    marginBottom: 12,
+    color: '#E74C3C',
+    textAlign: 'center',
+  },
+  message: {
+    fontSize: 16,
+    color: '#666',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  orderId: {
+    fontSize: 14,
+    color: '#999',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  redirect: {
+    fontSize: 14,
+    color: '#999',
+    marginTop: 24,
+    textAlign: 'center',
+  },
+});

--- a/app/checkout/success.tsx
+++ b/app/checkout/success.tsx
@@ -1,0 +1,77 @@
+import { useEffect } from 'react';
+import { View as RNView, StyleSheet } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { Text } from '@/components/Themed';
+
+export default function CheckoutSuccessScreen() {
+  const { order_id } = useLocalSearchParams<{ order_id?: string }>();
+
+  useEffect(() => {
+    // Navigate back to home after 2 seconds
+    const timer = setTimeout(() => {
+      router.replace('/(tabs)');
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <RNView style={styles.container}>
+      <RNView style={styles.content}>
+        <Text style={styles.emoji}>✅</Text>
+        <Text style={styles.title}>Payment Successful!</Text>
+        <Text style={styles.message}>
+          Your order has been placed successfully.
+        </Text>
+        {order_id && (
+          <Text style={styles.orderId}>Order ID: {order_id}</Text>
+        )}
+        <Text style={styles.redirect}>
+          Returning to the app...
+        </Text>
+      </RNView>
+    </RNView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    alignItems: 'center',
+    padding: 20,
+  },
+  emoji: {
+    fontSize: 64,
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    marginBottom: 12,
+    color: '#27AE60',
+    textAlign: 'center',
+  },
+  message: {
+    fontSize: 16,
+    color: '#666',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  orderId: {
+    fontSize: 14,
+    color: '#999',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  redirect: {
+    fontSize: 14,
+    color: '#999',
+    marginTop: 24,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
## Summary

Created screens to handle deep link redirects from Stripe checkout after payment completion. These screens provide seamless navigation when users complete or cancel payment in the Stripe checkout flow opened from the mobile app.

## Changes

- Added `/checkout/success` screen - Shows success message and auto-redirects to home
- Added `/checkout/cancel` screen - Shows cancellation message and auto-redirects to home
- Both screens extract order_id from query params for tracking
- Auto-redirect after 2 seconds to give users feedback before returning

## Deep Link Flow

1. User initiates sticker order in mobile app
2. App opens in-app browser to Stripe checkout
3. After payment completion, Stripe redirects to web success page
4. Web page deep links to `com.aceback.app://checkout/success?order_id={id}`
5. Mobile app opens and shows success screen
6. Success screen auto-redirects to home after 2 seconds

## Testing

- Complete a test purchase and verify success screen shows
- Cancel a payment and verify cancel screen shows
- Verify order_id displays correctly when present
- Verify auto-redirect to home works after 2 seconds

## Related

- Web PR: acebackapp/web#13 (adds deep linking from checkout pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)