### PR TITLE
feat: add dark mode support to order screens

### DIFF
--- a/app/my-orders.tsx
+++ b/app/my-orders.tsx
@@ -6,6 +6,7 @@ import {
   RefreshControl,
   ActivityIndicator,
   View as RNView,
+  useColorScheme,
 } from 'react-native';
 import { useRouter, Stack, useFocusEffect } from 'expo-router';
 import { Text, View } from '@/components/Themed';
@@ -45,9 +46,33 @@ function formatDate(dateString: string): string {
 
 export default function MyOrdersScreen() {
   const router = useRouter();
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
   const [orders, setOrders] = useState<StickerOrder[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#000' : '#fff',
+    },
+    orderCard: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : 'rgba(150, 150, 150, 0.2)',
+    },
+    orderDate: {
+      color: isDark ? '#999' : '#666',
+    },
+    orderDetailText: {
+      color: isDark ? '#999' : '#666',
+    },
+    trackingRow: {
+      borderTopColor: isDark ? '#333' : '#f0f0f0',
+    },
+    emptyDescription: {
+      color: isDark ? '#999' : '#666',
+    },
+  };
 
   const fetchOrders = async (isRefreshing = false) => {
     if (!isRefreshing) {
@@ -105,13 +130,13 @@ export default function MyOrdersScreen() {
 
     return (
       <Pressable
-        style={styles.orderCard}
+        style={[styles.orderCard, dynamicStyles.orderCard]}
         onPress={() => router.push(`/orders/${item.id}`)}
       >
         <RNView style={styles.orderHeader}>
           <RNView>
             <Text style={styles.orderNumber}>{item.order_number}</Text>
-            <Text style={styles.orderDate}>{formatDate(item.created_at)}</Text>
+            <Text style={[styles.orderDate, dynamicStyles.orderDate]}>{formatDate(item.created_at)}</Text>
           </RNView>
           <RNView style={[styles.statusBadge, { backgroundColor: statusConfig.color }]}>
             <FontAwesome name={statusConfig.icon as any} size={12} color="#fff" />
@@ -123,21 +148,21 @@ export default function MyOrdersScreen() {
 
         <RNView style={styles.orderDetails}>
           <RNView style={styles.orderDetailItem}>
-            <FontAwesome name="qrcode" size={16} color="#666" />
-            <Text style={styles.orderDetailText}>
+            <FontAwesome name="qrcode" size={16} color={isDark ? '#999' : '#666'} />
+            <Text style={[styles.orderDetailText, dynamicStyles.orderDetailText]}>
               {item.quantity} sticker{item.quantity !== 1 ? 's' : ''}
             </Text>
           </RNView>
           <RNView style={styles.orderDetailItem}>
-            <FontAwesome name="dollar" size={16} color="#666" />
-            <Text style={styles.orderDetailText}>
+            <FontAwesome name="dollar" size={16} color={isDark ? '#999' : '#666'} />
+            <Text style={[styles.orderDetailText, dynamicStyles.orderDetailText]}>
               ${(item.total_price_cents / 100).toFixed(2)}
             </Text>
           </RNView>
         </RNView>
 
         {item.tracking_number && (
-          <RNView style={styles.trackingRow}>
+          <RNView style={[styles.trackingRow, dynamicStyles.trackingRow]}>
             <FontAwesome name="truck" size={14} color={Colors.violet.primary} />
             <Text style={styles.trackingText}>Tracking: {item.tracking_number}</Text>
           </RNView>
@@ -154,7 +179,7 @@ export default function MyOrdersScreen() {
     <RNView style={styles.emptyState}>
       <FontAwesome name="shopping-bag" size={64} color="#ccc" style={styles.emptyIcon} />
       <Text style={styles.emptyTitle}>No Orders Yet</Text>
-      <Text style={styles.emptyDescription}>
+      <Text style={[styles.emptyDescription, dynamicStyles.emptyDescription]}>
         Order QR code stickers to protect your discs and help finders contact you.
       </Text>
       <Pressable style={styles.orderButton} onPress={() => router.push('/order-stickers')}>
@@ -178,7 +203,7 @@ export default function MyOrdersScreen() {
   return (
     <>
       <Stack.Screen options={{ title: 'My Orders', headerBackTitle: 'Back' }} />
-      <View style={styles.container}>
+      <View style={[styles.container, dynamicStyles.container]}>
         <FlatList
           data={orders}
           renderItem={renderOrderCard}
@@ -215,11 +240,10 @@ const styles = StyleSheet.create({
   },
   orderCard: {
     padding: 16,
+    paddingRight: 48,
     marginBottom: 12,
     borderRadius: 12,
-    backgroundColor: '#fff',
     borderWidth: 1,
-    borderColor: 'rgba(150, 150, 150, 0.2)',
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.05,
@@ -238,7 +262,6 @@ const styles = StyleSheet.create({
   },
   orderDate: {
     fontSize: 13,
-    color: '#666',
     marginTop: 2,
   },
   statusBadge: {
@@ -269,7 +292,6 @@ const styles = StyleSheet.create({
   },
   orderDetailText: {
     fontSize: 14,
-    color: '#666',
   },
   trackingRow: {
     flexDirection: 'row',
@@ -278,7 +300,6 @@ const styles = StyleSheet.create({
     marginTop: 12,
     paddingTop: 12,
     borderTopWidth: 1,
-    borderTopColor: '#f0f0f0',
   },
   trackingText: {
     fontSize: 13,
@@ -308,7 +329,6 @@ const styles = StyleSheet.create({
   },
   emptyDescription: {
     fontSize: 16,
-    color: '#666',
     textAlign: 'center',
     marginBottom: 24,
     lineHeight: 22,

--- a/app/orders/[id].tsx
+++ b/app/orders/[id].tsx
@@ -7,6 +7,7 @@ import {
   Linking,
   RefreshControl,
   View as RNView,
+  useColorScheme,
 } from 'react-native';
 import { useLocalSearchParams, Stack, useFocusEffect, useRouter } from 'expo-router';
 import { Text, View } from '@/components/Themed';
@@ -99,9 +100,62 @@ function getTrackingUrl(trackingNumber: string): string {
 export default function OrderDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
   const [order, setOrder] = useState<StickerOrder | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#000' : '#fff',
+    },
+    errorText: {
+      color: isDark ? '#999' : '#666',
+    },
+    timelineDot: {
+      backgroundColor: isDark ? '#444' : '#ddd',
+    },
+    timelineDotCurrentBorder: {
+      borderColor: isDark ? '#1a1a1a' : '#fff',
+    },
+    timelineLine: {
+      backgroundColor: isDark ? '#444' : '#ddd',
+    },
+    timelineLabel: {
+      color: isDark ? '#666' : '#999',
+    },
+    timelineLabelActive: {
+      color: isDark ? '#fff' : '#333',
+    },
+    timelineDate: {
+      color: isDark ? '#999' : '#666',
+    },
+    detailCard: {
+      backgroundColor: isDark ? '#1a1a1a' : '#f8f8f8',
+    },
+    detailLabel: {
+      color: isDark ? '#999' : '#666',
+    },
+    trackingCard: {
+      backgroundColor: isDark ? '#1a1a1a' : Colors.violet[50],
+    },
+    trackingIconContainer: {
+      backgroundColor: isDark ? '#2a2a2a' : '#fff',
+    },
+    trackingHint: {
+      color: isDark ? '#999' : '#666',
+    },
+    addressCard: {
+      backgroundColor: isDark ? '#1a1a1a' : '#f8f8f8',
+    },
+    addressLine: {
+      color: isDark ? '#999' : '#666',
+    },
+    helpText: {
+      color: isDark ? '#999' : '#666',
+    },
+  };
 
   const fetchOrder = async (isRefreshing = false) => {
     if (!isRefreshing) {
@@ -180,7 +234,7 @@ export default function OrderDetailScreen() {
         <Stack.Screen options={{ title: 'Order Details' }} />
         <View style={styles.centerContainer}>
           <FontAwesome name="exclamation-circle" size={48} color="#ccc" />
-          <Text style={styles.errorText}>Order not found</Text>
+          <Text style={[styles.errorText, dynamicStyles.errorText]}>Order not found</Text>
         </View>
       </>
     );
@@ -198,7 +252,7 @@ export default function OrderDetailScreen() {
         }}
       />
       <ScrollView
-        style={styles.container}
+        style={[styles.container, dynamicStyles.container]}
         contentContainerStyle={styles.content}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
       >
@@ -231,8 +285,10 @@ export default function OrderDetailScreen() {
                     <RNView
                       style={[
                         styles.timelineDot,
+                        dynamicStyles.timelineDot,
                         isPast && { backgroundColor: config.color },
                         isCurrent && styles.timelineDotCurrent,
+                        isCurrent && dynamicStyles.timelineDotCurrentBorder,
                       ]}
                     >
                       {isPast && <FontAwesome name="check" size={10} color="#fff" />}
@@ -241,23 +297,24 @@ export default function OrderDetailScreen() {
                       <RNView
                         style={[
                           styles.timelineLine,
+                          dynamicStyles.timelineLine,
                           isPast && index < currentStatusIndex && { backgroundColor: config.color },
                         ]}
                       />
                     )}
                   </RNView>
                   <RNView style={styles.timelineContent}>
-                    <Text style={[styles.timelineLabel, isPast && styles.timelineLabelActive]}>
+                    <Text style={[styles.timelineLabel, dynamicStyles.timelineLabel, isPast && styles.timelineLabelActive, isPast && dynamicStyles.timelineLabelActive]}>
                       {config.label}
                     </Text>
                     {status === 'paid' && order.paid_at && (
-                      <Text style={styles.timelineDate}>{formatDateTime(order.paid_at)}</Text>
+                      <Text style={[styles.timelineDate, dynamicStyles.timelineDate]}>{formatDateTime(order.paid_at)}</Text>
                     )}
                     {status === 'printed' && order.printed_at && (
-                      <Text style={styles.timelineDate}>{formatDateTime(order.printed_at)}</Text>
+                      <Text style={[styles.timelineDate, dynamicStyles.timelineDate]}>{formatDateTime(order.printed_at)}</Text>
                     )}
                     {status === 'shipped' && order.shipped_at && (
-                      <Text style={styles.timelineDate}>{formatDateTime(order.shipped_at)}</Text>
+                      <Text style={[styles.timelineDate, dynamicStyles.timelineDate]}>{formatDateTime(order.shipped_at)}</Text>
                     )}
                   </RNView>
                 </RNView>
@@ -269,30 +326,30 @@ export default function OrderDetailScreen() {
         {/* Order Details */}
         <RNView style={styles.section}>
           <Text style={styles.sectionTitle}>Order Details</Text>
-          <RNView style={styles.detailCard}>
+          <RNView style={[styles.detailCard, dynamicStyles.detailCard]}>
             <RNView style={styles.detailRow}>
-              <Text style={styles.detailLabel}>Order Number</Text>
+              <Text style={[styles.detailLabel, dynamicStyles.detailLabel]}>Order Number</Text>
               <Text style={styles.detailValue}>{order.order_number}</Text>
             </RNView>
             <RNView style={styles.detailRow}>
-              <Text style={styles.detailLabel}>Order Date</Text>
+              <Text style={[styles.detailLabel, dynamicStyles.detailLabel]}>Order Date</Text>
               <Text style={styles.detailValue}>{formatDate(order.created_at)}</Text>
             </RNView>
             <RNView style={styles.detailRow}>
-              <Text style={styles.detailLabel}>Quantity</Text>
+              <Text style={[styles.detailLabel, dynamicStyles.detailLabel]}>Quantity</Text>
               <Text style={styles.detailValue}>
                 {order.quantity} sticker{order.quantity !== 1 ? 's' : ''}
               </Text>
             </RNView>
             <View style={styles.detailDivider} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
             <RNView style={styles.detailRow}>
-              <Text style={styles.detailLabel}>Subtotal</Text>
+              <Text style={[styles.detailLabel, dynamicStyles.detailLabel]}>Subtotal</Text>
               <Text style={styles.detailValue}>
                 ${((order.quantity * order.unit_price_cents) / 100).toFixed(2)}
               </Text>
             </RNView>
             <RNView style={styles.detailRow}>
-              <Text style={styles.detailLabel}>Shipping</Text>
+              <Text style={[styles.detailLabel, dynamicStyles.detailLabel]}>Shipping</Text>
               <Text style={[styles.detailValue, styles.freeText]}>FREE</Text>
             </RNView>
             <View style={styles.detailDivider} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
@@ -309,13 +366,13 @@ export default function OrderDetailScreen() {
         {order.tracking_number && (
           <RNView style={styles.section}>
             <Text style={styles.sectionTitle}>Tracking Information</Text>
-            <Pressable style={styles.trackingCard} onPress={handleTrackPackage}>
-              <RNView style={styles.trackingIconContainer}>
+            <Pressable style={[styles.trackingCard, dynamicStyles.trackingCard]} onPress={handleTrackPackage}>
+              <RNView style={[styles.trackingIconContainer, dynamicStyles.trackingIconContainer]}>
                 <FontAwesome name="truck" size={24} color={Colors.violet.primary} />
               </RNView>
               <RNView style={styles.trackingInfo}>
                 <Text style={styles.trackingNumber}>{order.tracking_number}</Text>
-                <Text style={styles.trackingHint}>Tap to track your package</Text>
+                <Text style={[styles.trackingHint, dynamicStyles.trackingHint]}>Tap to track your package</Text>
               </RNView>
               <FontAwesome name="chevron-right" size={16} color="#ccc" />
             </Pressable>
@@ -326,19 +383,19 @@ export default function OrderDetailScreen() {
         {order.shipping_address && (
           <RNView style={styles.section}>
             <Text style={styles.sectionTitle}>Shipping Address</Text>
-            <RNView style={styles.addressCard}>
+            <RNView style={[styles.addressCard, dynamicStyles.addressCard]}>
               <FontAwesome name="map-marker" size={20} color={Colors.violet.primary} />
               <RNView style={styles.addressText}>
                 <Text style={styles.addressName}>{order.shipping_address.name}</Text>
-                <Text style={styles.addressLine}>{order.shipping_address.street_address}</Text>
+                <Text style={[styles.addressLine, dynamicStyles.addressLine]}>{order.shipping_address.street_address}</Text>
                 {order.shipping_address.street_address_2 && (
-                  <Text style={styles.addressLine}>{order.shipping_address.street_address_2}</Text>
+                  <Text style={[styles.addressLine, dynamicStyles.addressLine]}>{order.shipping_address.street_address_2}</Text>
                 )}
-                <Text style={styles.addressLine}>
+                <Text style={[styles.addressLine, dynamicStyles.addressLine]}>
                   {order.shipping_address.city}, {order.shipping_address.state}{' '}
                   {order.shipping_address.postal_code}
                 </Text>
-                <Text style={styles.addressLine}>{order.shipping_address.country}</Text>
+                <Text style={[styles.addressLine, dynamicStyles.addressLine]}>{order.shipping_address.country}</Text>
               </RNView>
             </RNView>
           </RNView>
@@ -346,7 +403,7 @@ export default function OrderDetailScreen() {
 
         {/* Help Section */}
         <RNView style={styles.section}>
-          <Text style={styles.helpText}>
+          <Text style={[styles.helpText, dynamicStyles.helpText]}>
             Need help with your order? Contact us at{' '}
             <Text
               style={styles.helpLink}
@@ -376,7 +433,6 @@ const styles = StyleSheet.create({
   },
   errorText: {
     fontSize: 16,
-    color: '#666',
     marginTop: 12,
   },
   statusHeader: {
@@ -427,13 +483,11 @@ const styles = StyleSheet.create({
     width: 24,
     height: 24,
     borderRadius: 12,
-    backgroundColor: '#ddd',
     alignItems: 'center',
     justifyContent: 'center',
   },
   timelineDotCurrent: {
     borderWidth: 3,
-    borderColor: '#fff',
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.2,
@@ -443,7 +497,6 @@ const styles = StyleSheet.create({
   timelineLine: {
     width: 2,
     flex: 1,
-    backgroundColor: '#ddd',
     marginVertical: 4,
   },
   timelineContent: {
@@ -453,19 +506,15 @@ const styles = StyleSheet.create({
   },
   timelineLabel: {
     fontSize: 14,
-    color: '#999',
   },
   timelineLabelActive: {
-    color: '#333',
     fontWeight: '500',
   },
   timelineDate: {
     fontSize: 12,
-    color: '#666',
     marginTop: 2,
   },
   detailCard: {
-    backgroundColor: '#f8f8f8',
     borderRadius: 12,
     padding: 16,
   },
@@ -476,7 +525,6 @@ const styles = StyleSheet.create({
   },
   detailLabel: {
     fontSize: 14,
-    color: '#666',
   },
   detailValue: {
     fontSize: 14,
@@ -501,7 +549,6 @@ const styles = StyleSheet.create({
   trackingCard: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: Colors.violet[50],
     borderRadius: 12,
     padding: 16,
   },
@@ -509,7 +556,6 @@ const styles = StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 24,
-    backgroundColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -524,12 +570,10 @@ const styles = StyleSheet.create({
   },
   trackingHint: {
     fontSize: 12,
-    color: '#666',
     marginTop: 2,
   },
   addressCard: {
     flexDirection: 'row',
-    backgroundColor: '#f8f8f8',
     borderRadius: 12,
     padding: 16,
     gap: 12,
@@ -544,12 +588,10 @@ const styles = StyleSheet.create({
   },
   addressLine: {
     fontSize: 14,
-    color: '#666',
     lineHeight: 20,
   },
   helpText: {
     fontSize: 14,
-    color: '#666',
     textAlign: 'center',
     marginTop: 8,
   },


### PR DESCRIPTION
## Summary

- Added comprehensive dark mode support to my orders list page
- Added comprehensive dark mode support to order details page
- Updated backgrounds, text colors, and cards for dark theme
- Added extra right padding to order cards to prevent chevron crowding
- Followed dark mode guidelines from CLAUDE.md
- Removed hardcoded colors from StyleSheet, using dynamic styles instead

## Screenshots

Please test in both light and dark modes on iOS device.

## Test plan

- [ ] View my orders page in light mode - verify proper colors and spacing
- [ ] View my orders page in dark mode - verify proper colors and spacing
- [ ] View order details page in light mode - verify all sections display correctly
- [ ] View order details page in dark mode - verify all sections display correctly
- [ ] Verify chevron arrow on order cards has proper spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)