### PR TITLE
feat: improve shipping address UX with prefill and checkbox defaults

### DIFF
--- a/__tests__/app/order-stickers.test.tsx
+++ b/__tests__/app/order-stickers.test.tsx
@@ -179,7 +179,7 @@ describe('OrderStickersScreen', () => {
       );
     });
 
-    it('checkbox defaults to unchecked when address exists', async () => {
+    it('checkbox defaults to checked when address exists', async () => {
       mockFetch.mockImplementation((url: string) => {
         if (url.includes('get-default-address')) {
           return Promise.resolve({
@@ -208,7 +208,7 @@ describe('OrderStickersScreen', () => {
         expect(getByDisplayValue('John Doe')).toBeTruthy();
       });
 
-      // Checkbox should still be visible
+      // Checkbox should be visible and checked by default
       expect(getByText('Save as my default address')).toBeTruthy();
     });
 
@@ -391,6 +391,9 @@ describe('OrderStickersScreen', () => {
       await waitFor(() => {
         expect(getByDisplayValue('John Doe')).toBeTruthy();
       });
+
+      // Toggle checkbox OFF (it's checked by default now)
+      fireEvent.press(getByText('Save as my default address'));
 
       // Clear the previous mock calls
       mockFetch.mockClear();

--- a/__tests__/tabs/profile.test.tsx
+++ b/__tests__/tabs/profile.test.tsx
@@ -427,6 +427,23 @@ describe('ProfileScreen', () => {
       });
     });
 
+    it('pre-fills name with profile full name when adding new address', async () => {
+      const { getByText, getByDisplayValue } = render(<ProfileScreen />);
+
+      // Wait for profile to load (mock returns full_name: 'Test User')
+      await waitFor(() => {
+        expect(getByText('Test User')).toBeTruthy();
+      });
+
+      // Click Add Shipping Address
+      fireEvent.press(getByText('Add Shipping Address'));
+
+      // Name field should be pre-filled with profile full name
+      await waitFor(() => {
+        expect(getByDisplayValue('Test User')).toBeTruthy();
+      });
+    });
+
     it('opens edit form when pressing existing address', async () => {
       mockFetch.mockImplementation((url: string) => {
         if (url.includes('get-default-address')) {
@@ -470,7 +487,7 @@ describe('ProfileScreen', () => {
     });
 
     it('shows validation error for missing name', async () => {
-      const { getByText, getByPlaceholderText } = render(<ProfileScreen />);
+      const { getByText, getByDisplayValue } = render(<ProfileScreen />);
 
       await waitFor(() => {
         expect(getByText('Add Shipping Address')).toBeTruthy();
@@ -478,11 +495,14 @@ describe('ProfileScreen', () => {
 
       fireEvent.press(getByText('Add Shipping Address'));
 
+      // Name is pre-filled with profile full name, clear it
       await waitFor(() => {
-        expect(getByPlaceholderText('Full name')).toBeTruthy();
+        expect(getByDisplayValue('Test User')).toBeTruthy();
       });
 
-      // Try to save without entering name
+      fireEvent.changeText(getByDisplayValue('Test User'), '');
+
+      // Try to save without name
       fireEvent.press(getByText('Save Address'));
 
       await waitFor(() => {

--- a/app/(tabs)/two.tsx
+++ b/app/(tabs)/two.tsx
@@ -695,7 +695,7 @@ export default function ProfileScreen() {
   const handleEditShippingAddress = () => {
     setTempShippingAddress(shippingAddress || {
       id: null,
-      name: '',
+      name: profile.full_name || '',
       street_address: '',
       street_address_2: '',
       city: '',

--- a/app/order-stickers.tsx
+++ b/app/order-stickers.tsx
@@ -94,10 +94,9 @@ export default function OrderStickersScreen() {
           });
           setDefaultAddressId(defaultAddress.id);
           setHasDefaultAddress(true);
-        } else {
-          // No default address - default checkbox to checked for first-time users
-          setSaveAsDefault(true);
         }
+        // Always default checkbox to checked so any edits are saved
+        setSaveAsDefault(true);
       }
     } catch (error) {
       console.error('Error fetching default address:', error);


### PR DESCRIPTION
## Summary
- Pre-fill name field with user's profile full name when clicking "Add Shipping Address"
- Default "Save as my default address" checkbox to checked even when address already exists
- Any edits to the address during checkout are now saved by default

## Changes
- `app/(tabs)/two.tsx`: Use `profile.full_name` as default name when adding new address
- `app/order-stickers.tsx`: Always set `saveAsDefault` to true after fetching address
- Updated tests to reflect new behavior

## Test plan
- [ ] Profile tab: Click "Add Shipping Address" - name should pre-fill with full name
- [ ] Order form: Pre-saved address should have checkbox checked by default
- [ ] Order form: Edits to address are saved when checkbox remains checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)