### PR TITLE
feat: integrate USPS address validation in order checkout

### DIFF
--- a/__tests__/app/order-stickers.test.tsx
+++ b/__tests__/app/order-stickers.test.tsx
@@ -50,6 +50,15 @@ describe('OrderStickersScreen', () => {
           json: () => Promise.resolve(null),
         });
       }
+      if (url.includes('validate-address')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            valid: true,
+            // No standardized = address is valid as-is
+          }),
+        });
+      }
       if (url.includes('save-default-address')) {
         return Promise.resolve({
           ok: true,
@@ -320,7 +329,7 @@ describe('OrderStickersScreen', () => {
       fireEvent.press(getByText(/Pay \$/));
 
       await waitFor(() => {
-        expect(Alert.alert).toHaveBeenCalledWith('Missing Information', 'Postal code is required');
+        expect(Alert.alert).toHaveBeenCalledWith('Missing Information', 'ZIP code is required');
       });
     });
   });
@@ -370,6 +379,12 @@ describe('OrderStickersScreen', () => {
             }),
           });
         }
+        if (url.includes('validate-address')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ valid: true }),
+          });
+        }
         if (url.includes('create-sticker-order')) {
           return Promise.resolve({
             ok: true,
@@ -400,6 +415,12 @@ describe('OrderStickersScreen', () => {
 
       // Reset mock to track calls
       mockFetch.mockImplementation((url: string) => {
+        if (url.includes('validate-address')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ valid: true }),
+          });
+        }
         if (url.includes('create-sticker-order')) {
           return Promise.resolve({
             ok: true,
@@ -438,6 +459,12 @@ describe('OrderStickersScreen', () => {
           return Promise.resolve({
             ok: true,
             json: () => Promise.resolve(null),
+          });
+        }
+        if (url.includes('validate-address')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ valid: true }),
           });
         }
         if (url.includes('save-default-address')) {


### PR DESCRIPTION
## Summary

- Integrates USPS address validation into the sticker order checkout flow
- Validates addresses before proceeding to Stripe checkout
- Shows modal with suggested standardized address when USPS has corrections
- Users can accept the USPS suggestion or keep their original address
- Displays validation errors when address cannot be validated

## Changes

- `app/order-stickers.tsx` - Added USPS validation integration with modal UI
- `__tests__/app/order-stickers.test.tsx` - Updated tests to mock validate-address endpoint

## User Flow

1. User fills in shipping address
2. User clicks "Pay"
3. Client-side validation runs (state code, ZIP format)
4. USPS API validation runs via `validate-address` edge function
5. **If address needs correction:** Modal shows both original and suggested address
   - User can "Use Suggested Address" or "Keep My Address"
6. **If address is invalid:** Modal shows error messages
7. **If address is valid:** Proceeds directly to Stripe checkout

## UI Screenshots

The modal shows:
- "Suggested Address" title with comparison of original vs USPS standardized
- "Use Suggested Address" (primary button) 
- "Keep My Address" (secondary button)

For errors:
- "Address Issue" title
- List of validation errors from USPS
- "Edit Address" button to go back

## Test plan

- [x] All 462 tests passing
- [x] TypeScript type checking passes
- [x] Pre-commit hooks pass
- [ ] Manual test with real address to verify USPS integration
- [ ] Test with invalid address to verify error display
- [ ] Test with address that needs correction to verify modal

Closes #146 (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)