### PR TITLE
feat: add Venmo reward payment system

### DIFF
--- a/__tests__/lib/venmoDeepLink.test.ts
+++ b/__tests__/lib/venmoDeepLink.test.ts
@@ -1,0 +1,220 @@
+import { Linking } from 'react-native';
+import {
+  generatePaymentNote,
+  getVenmoAppUrl,
+  getVenmoWebUrl,
+  isValidVenmoUsername,
+  formatVenmoUsername,
+  openVenmoPayment,
+  isVenmoInstalled,
+} from '../../lib/venmoDeepLink';
+
+// Mock Linking
+jest.mock('react-native', () => ({
+  Linking: {
+    canOpenURL: jest.fn(),
+    openURL: jest.fn(),
+  },
+  Platform: {
+    OS: 'ios',
+  },
+}));
+
+describe('venmoDeepLink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generatePaymentNote', () => {
+    it('generates note with disc name', () => {
+      const note = generatePaymentNote('Destroyer');
+      expect(note).toBe('🥏 Destroyer Returned via AceBack');
+    });
+
+    it('generates generic note without disc name', () => {
+      const note = generatePaymentNote();
+      expect(note).toBe('🥏 Disc Returned via AceBack');
+    });
+
+    it('generates generic note with undefined disc name', () => {
+      const note = generatePaymentNote(undefined);
+      expect(note).toBe('🥏 Disc Returned via AceBack');
+    });
+  });
+
+  describe('getVenmoAppUrl', () => {
+    it('generates correct app URL with all params', () => {
+      const url = getVenmoAppUrl({
+        recipientUsername: 'John-Doe-5',
+        amount: 10,
+        discName: 'Destroyer',
+      });
+      expect(url).toBe(
+        'venmo://paycharge?txn=pay&recipients=John-Doe-5&amount=10&note=%F0%9F%A5%8F%20Destroyer%20Returned%20via%20AceBack'
+      );
+    });
+
+    it('strips @ from username', () => {
+      const url = getVenmoAppUrl({
+        recipientUsername: '@John-Doe-5',
+        amount: 15.5,
+      });
+      expect(url).toContain('recipients=John-Doe-5');
+      expect(url).not.toContain('recipients=@');
+    });
+
+    it('uses custom note when provided', () => {
+      const url = getVenmoAppUrl({
+        recipientUsername: 'test-user',
+        amount: 5,
+        customNote: 'Custom payment note',
+      });
+      expect(url).toContain('note=Custom%20payment%20note');
+    });
+
+    it('handles decimal amounts', () => {
+      const url = getVenmoAppUrl({
+        recipientUsername: 'test-user',
+        amount: 12.50,
+      });
+      expect(url).toContain('amount=12.5');
+    });
+  });
+
+  describe('getVenmoWebUrl', () => {
+    it('generates correct web URL', () => {
+      const url = getVenmoWebUrl({
+        recipientUsername: 'John-Doe-5',
+        amount: 10,
+        discName: 'Valkyrie',
+      });
+      expect(url).toBe(
+        'https://venmo.com/?txn=pay&recipients=John-Doe-5&amount=10&note=%F0%9F%A5%8F%20Valkyrie%20Returned%20via%20AceBack'
+      );
+    });
+
+    it('strips @ from username', () => {
+      const url = getVenmoWebUrl({
+        recipientUsername: '@test-user',
+        amount: 20,
+      });
+      expect(url).toContain('recipients=test-user');
+      expect(url).not.toContain('recipients=@');
+    });
+  });
+
+  describe('isValidVenmoUsername', () => {
+    it('accepts valid usernames', () => {
+      expect(isValidVenmoUsername('John-Doe-5')).toBe(true);
+      expect(isValidVenmoUsername('johndoe')).toBe(true);
+      expect(isValidVenmoUsername('john123')).toBe(true);
+      expect(isValidVenmoUsername('Test-User-123')).toBe(true);
+    });
+
+    it('accepts username with @ prefix', () => {
+      expect(isValidVenmoUsername('@John-Doe-5')).toBe(true);
+    });
+
+    it('rejects empty username', () => {
+      expect(isValidVenmoUsername('')).toBe(false);
+    });
+
+    it('rejects username with consecutive dashes', () => {
+      expect(isValidVenmoUsername('john--doe')).toBe(false);
+    });
+
+    it('rejects too short usernames', () => {
+      expect(isValidVenmoUsername('abc')).toBe(false);
+    });
+
+    it('rejects usernames starting or ending with dash', () => {
+      expect(isValidVenmoUsername('-johndoe')).toBe(false);
+      expect(isValidVenmoUsername('johndoe-')).toBe(false);
+    });
+  });
+
+  describe('formatVenmoUsername', () => {
+    it('adds @ prefix', () => {
+      expect(formatVenmoUsername('johndoe')).toBe('@johndoe');
+    });
+
+    it('does not double @ prefix', () => {
+      expect(formatVenmoUsername('@johndoe')).toBe('@johndoe');
+    });
+
+    it('handles empty string', () => {
+      expect(formatVenmoUsername('')).toBe('');
+    });
+  });
+
+  describe('isVenmoInstalled', () => {
+    it('returns true when Venmo app is available', async () => {
+      (Linking.canOpenURL as jest.Mock).mockResolvedValue(true);
+      const result = await isVenmoInstalled();
+      expect(result).toBe(true);
+      expect(Linking.canOpenURL).toHaveBeenCalledWith('venmo://');
+    });
+
+    it('returns false when Venmo app is not available', async () => {
+      (Linking.canOpenURL as jest.Mock).mockResolvedValue(false);
+      const result = await isVenmoInstalled();
+      expect(result).toBe(false);
+    });
+
+    it('returns false on error', async () => {
+      (Linking.canOpenURL as jest.Mock).mockRejectedValue(new Error('test error'));
+      const result = await isVenmoInstalled();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('openVenmoPayment', () => {
+    const params = {
+      recipientUsername: 'test-user',
+      amount: 10,
+      discName: 'Destroyer',
+    };
+
+    it('opens Venmo app when available', async () => {
+      (Linking.canOpenURL as jest.Mock).mockResolvedValue(true);
+      (Linking.openURL as jest.Mock).mockResolvedValue(true);
+
+      const result = await openVenmoPayment(params);
+
+      expect(result).toBe(true);
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        expect.stringContaining('venmo://paycharge')
+      );
+    });
+
+    it('falls back to web URL when app not available', async () => {
+      (Linking.canOpenURL as jest.Mock)
+        .mockResolvedValueOnce(false) // App not available
+        .mockResolvedValueOnce(true); // Web available
+      (Linking.openURL as jest.Mock).mockResolvedValue(true);
+
+      const result = await openVenmoPayment(params);
+
+      expect(result).toBe(true);
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        expect.stringContaining('https://venmo.com')
+      );
+    });
+
+    it('returns false when neither app nor web available', async () => {
+      (Linking.canOpenURL as jest.Mock).mockResolvedValue(false);
+
+      const result = await openVenmoPayment(params);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false on error', async () => {
+      (Linking.canOpenURL as jest.Mock).mockRejectedValue(new Error('test error'));
+
+      const result = await openVenmoPayment(params);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/app.json
+++ b/app.json
@@ -20,6 +20,9 @@
         "usesNonExemptEncryption": false
       },
       "associatedDomains": ["applinks:aceback.app"],
+      "infoPlist": {
+        "LSApplicationQueriesSchemes": ["venmo"]
+      },
       "splash": {
         "image": "./assets/images/splash-icon.png",
         "resizeMode": "contain",

--- a/lib/venmoDeepLink.ts
+++ b/lib/venmoDeepLink.ts
@@ -1,0 +1,124 @@
+import { Linking, Platform } from 'react-native';
+
+/**
+ * Venmo Deep Link Utility
+ *
+ * Opens the Venmo app (or web fallback) with pre-filled payment details.
+ * Used for sending rewards when a disc is returned.
+ *
+ * Deep link format: venmo://paycharge?txn=pay&recipients={username}&amount={amount}&note={note}
+ * Web fallback: https://venmo.com/?txn=pay&recipients={username}&amount={amount}&note={note}
+ *
+ * @see https://blog.alexbeals.com/posts/venmo-deeplinking
+ */
+
+export interface VenmoPaymentParams {
+  /** Venmo username of the recipient (without @) */
+  recipientUsername: string;
+  /** Amount to pay in dollars */
+  amount: number;
+  /** Optional disc name to include in the note */
+  discName?: string;
+  /** Optional custom note (defaults to disc return message) */
+  customNote?: string;
+}
+
+/**
+ * Generates the payment note for Venmo
+ */
+export const generatePaymentNote = (discName?: string): string => {
+  if (discName) {
+    return `🥏 ${discName} Returned via AceBack`;
+  }
+  return '🥏 Disc Returned via AceBack';
+};
+
+/**
+ * Generates the Venmo app deep link URL
+ */
+export const getVenmoAppUrl = (params: VenmoPaymentParams): string => {
+  const { recipientUsername, amount, discName, customNote } = params;
+  const note = encodeURIComponent(customNote || generatePaymentNote(discName));
+  // Remove @ if user included it
+  const username = recipientUsername.replace(/^@/, '');
+
+  return `venmo://paycharge?txn=pay&recipients=${username}&amount=${amount}&note=${note}`;
+};
+
+/**
+ * Generates the Venmo web fallback URL
+ */
+export const getVenmoWebUrl = (params: VenmoPaymentParams): string => {
+  const { recipientUsername, amount, discName, customNote } = params;
+  const note = encodeURIComponent(customNote || generatePaymentNote(discName));
+  // Remove @ if user included it
+  const username = recipientUsername.replace(/^@/, '');
+
+  return `https://venmo.com/?txn=pay&recipients=${username}&amount=${amount}&note=${note}`;
+};
+
+/**
+ * Checks if the Venmo app is installed on the device
+ */
+export const isVenmoInstalled = async (): Promise<boolean> => {
+  try {
+    return await Linking.canOpenURL('venmo://');
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Opens Venmo with pre-filled payment details
+ * Falls back to web URL if Venmo app is not installed
+ *
+ * @returns true if successfully opened, false otherwise
+ */
+export const openVenmoPayment = async (params: VenmoPaymentParams): Promise<boolean> => {
+  try {
+    const venmoAppUrl = getVenmoAppUrl(params);
+    const venmoWebUrl = getVenmoWebUrl(params);
+
+    // Try to open Venmo app first
+    const canOpenApp = await Linking.canOpenURL(venmoAppUrl);
+
+    if (canOpenApp) {
+      await Linking.openURL(venmoAppUrl);
+      return true;
+    }
+
+    // Fall back to web URL
+    const canOpenWeb = await Linking.canOpenURL(venmoWebUrl);
+    if (canOpenWeb) {
+      await Linking.openURL(venmoWebUrl);
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    console.error('Error opening Venmo:', error);
+    return false;
+  }
+};
+
+/**
+ * Validates a Venmo username format
+ * Venmo usernames can contain letters, numbers, and dashes
+ */
+export const isValidVenmoUsername = (username: string): boolean => {
+  if (!username) return false;
+  // Remove @ if present
+  const cleanUsername = username.replace(/^@/, '');
+  // Venmo usernames: 5-30 chars, alphanumeric and dashes, no consecutive dashes
+  const venmoUsernameRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{3,28})[a-zA-Z0-9]$/;
+  return venmoUsernameRegex.test(cleanUsername) && !cleanUsername.includes('--');
+};
+
+/**
+ * Formats a Venmo username for display (with @)
+ */
+export const formatVenmoUsername = (username: string): string => {
+  if (!username) return '';
+  const cleanUsername = username.replace(/^@/, '');
+  return `@${cleanUsername}`;
+};


### PR DESCRIPTION
## Summary

- Add `venmoDeepLink.ts` utility for opening Venmo with pre-filled payment details
- Add `venmo_username` field to profile settings (Payment Settings section)
- Add Venmo payment button to recovery completion screen
- Update iOS config with `LSApplicationQueriesSchemes` for Venmo URL detection
- Add 25 tests for Venmo deep link utility

## How It Works

1. **Owner sets up Venmo**: In Profile → Payment Settings, owner adds their Venmo username
2. **Owner sets reward**: When adding/editing a disc, owner sets a reward amount
3. **Finder returns disc**: After marking disc as recovered, finder sees "Send $X Reward via Venmo" button
4. **One-tap payment**: Button opens Venmo app with:
   - Recipient: owner's Venmo username
   - Amount: reward amount
   - Note: "🥏 [Disc Name] Returned via AceBack"

## Deep Link Format

```
venmo://paycharge?txn=pay&recipients={username}&amount={amount}&note={note}
```

Falls back to web URL if Venmo app isn't installed.

## Test plan

- [x] All 512 tests passing (487 existing + 25 new)
- [ ] Add Venmo username in profile settings
- [ ] Verify Venmo button appears on recovered disc (as finder)
- [ ] Test Venmo deep link opens correctly
- [ ] Test web fallback when Venmo not installed

**Depends on:** acebackapp/api PR for venmo_username migration

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)