### PR TITLE
fix: owner pays finder reward via Venmo + default meetup time 1hr ahead

### DIFF
--- a/app/propose-meetup/[id].tsx
+++ b/app/propose-meetup/[id].tsx
@@ -27,8 +27,14 @@ export default function ProposeMeetupScreen() {
 
   const [locationName, setLocationName] = useState('');
   const [message, setMessage] = useState('');
-  const [proposedDate, setProposedDate] = useState(new Date());
-  const [tempDate, setTempDate] = useState(new Date()); // Temp date for iOS picker
+  // Default to 1 hour from now for convenience
+  const getDefaultTime = () => {
+    const date = new Date();
+    date.setHours(date.getHours() + 1);
+    return date;
+  };
+  const [proposedDate, setProposedDate] = useState(getDefaultTime);
+  const [tempDate, setTempDate] = useState(getDefaultTime); // Temp date for iOS picker
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [showTimePicker, setShowTimePicker] = useState(false);
   const [submitting, setSubmitting] = useState(false);

--- a/app/recovery/[id].tsx
+++ b/app/recovery/[id].tsx
@@ -72,6 +72,7 @@ interface RecoveryDetails {
     id: string;
     display_name: string;
     avatar_url?: string | null;
+    venmo_username?: string | null;
   };
   meetup_proposals: MeetupProposal[];
   drop_off?: DropOff | null;
@@ -486,13 +487,13 @@ export default function RecoveryDetailScreen() {
   };
 
   const handleSendReward = async () => {
-    if (!recovery?.owner.venmo_username || !recovery.disc?.reward_amount) {
-      Alert.alert('Error', 'Unable to send reward. Owner may not have Venmo set up.');
+    if (!recovery?.finder.venmo_username || !recovery.disc?.reward_amount) {
+      Alert.alert('Error', 'Unable to send reward. The finder may not have Venmo set up.');
       return;
     }
 
     const success = await openVenmoPayment({
-      recipientUsername: recovery.owner.venmo_username,
+      recipientUsername: recovery.finder.venmo_username,
       amount: recovery.disc.reward_amount,
       discName: recovery.disc.mold || recovery.disc.name,
     });
@@ -624,8 +625,8 @@ export default function RecoveryDetailScreen() {
             This disc was successfully returned on {formatDate(recovery.recovered_at || recovery.updated_at)}
           </Text>
 
-          {/* Venmo reward button - shown to finder when owner has Venmo and reward set */}
-          {!isOwner && recovery.disc?.reward_amount && recovery.disc.reward_amount > 0 && recovery.owner.venmo_username && (
+          {/* Venmo reward button - shown to owner when finder has Venmo and reward set */}
+          {isOwner && recovery.disc?.reward_amount && recovery.disc.reward_amount > 0 && recovery.finder.venmo_username && (
             <Pressable style={styles.venmoButton} onPress={handleSendReward}>
               <RNView style={styles.venmoIconBox}>
                 <Text style={styles.venmoIconText}>V</Text>
@@ -636,12 +637,12 @@ export default function RecoveryDetailScreen() {
             </Pressable>
           )}
 
-          {/* Show message if reward exists but owner has no Venmo */}
-          {!isOwner && recovery.disc?.reward_amount && recovery.disc.reward_amount > 0 && !recovery.owner.venmo_username && (
+          {/* Show message if reward exists but finder has no Venmo */}
+          {isOwner && recovery.disc?.reward_amount && recovery.disc.reward_amount > 0 && !recovery.finder.venmo_username && (
             <RNView style={styles.noVenmoMessage}>
               <FontAwesome name="info-circle" size={16} color="#666" />
               <Text style={styles.noVenmoText}>
-                Contact {recovery.owner.display_name} directly to receive your ${recovery.disc.reward_amount} reward
+                Contact {recovery.finder.display_name} directly to send the ${recovery.disc.reward_amount} reward
               </Text>
             </RNView>
           )}


### PR DESCRIPTION
## Summary

Two fixes in this PR:

### 1. Venmo Reward Button Fix
The reward button was showing to the wrong user. The **owner** should pay the **finder** for returning their disc.

**Changes:**
- Button now shows to disc owner (not finder)
- Payment goes to finder's Venmo username
- Added `venmo_username` to finder interface
- Updated messages to reflect correct flow

### 2. Meetup Proposal Default Time
- Default time now set to 1 hour from current time
- More practical than defaulting to "now"
- Avoids immediate "must be in the future" validation errors

## Test plan

- [x] Verify owner sees Venmo button on recovered disc (when finder has Venmo set)
- [x] Verify button opens Venmo with finder as recipient
- [x] Verify meetup proposal defaults to 1 hour ahead
- [ ] Test on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)