### PR TITLE
fix: use raw text in Venmo app URL to avoid + signs

### DIFF
--- a/__tests__/lib/venmoDeepLink.test.ts
+++ b/__tests__/lib/venmoDeepLink.test.ts
@@ -69,8 +69,8 @@ describe('venmoDeepLink', () => {
         amount: 5,
         customNote: 'Custom payment note',
       });
-      // Spaces are preserved in app URL
-      expect(url).toContain('note=Custom payment note');
+      // Raw text is used in app URL (no encoding)
+      expect(url).toBe('venmo://paycharge?txn=pay&recipients=test-user&amount=5&note=Custom payment note');
     });
 
     it('handles decimal amounts', () => {

--- a/lib/venmoDeepLink.ts
+++ b/lib/venmoDeepLink.ts
@@ -36,14 +36,13 @@ export const generatePaymentNote = (discName?: string): string => {
 
 /**
  * Generates the Venmo app deep link URL
- * Note: For app deep links, we encode but then convert %20 back to spaces
- * as Venmo's app handles literal spaces better than encoded ones
+ * Note: For app deep links, we don't encode the note - Venmo handles raw text
+ * Encoding causes + signs to appear instead of spaces
  */
 export const getVenmoAppUrl = (params: VenmoPaymentParams): string => {
   const { recipientUsername, amount, discName, customNote } = params;
-  const rawNote = customNote || generatePaymentNote(discName);
-  // Encode first, then replace %20 with actual spaces for the app deep link
-  const note = encodeURIComponent(rawNote).replace(/%20/g, ' ');
+  // Don't encode the note for app deep links - use raw text
+  const note = customNote || generatePaymentNote(discName);
   // Remove @ if user included it
   const username = recipientUsername.replace(/^@/, '');
 


### PR DESCRIPTION
## Summary

Don't encode the note at all for Venmo app deep links - encoding was causing `+` signs to appear instead of spaces.

Previous attempts with `%20` encoding and then replacing with spaces didn't work because something in the iOS URL handling chain was still converting them.

## Test plan

- [x] All 25 venmoDeepLink tests pass
- [ ] Test on device - verify note displays with spaces, not `+`

🤖 Generated with [Claude Code](https://claude.com/claude-code)