### PR TITLE
refactor: rename app from AceBack to Discr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
-# AceBack Mobile - Project Memory
+# Discr Mobile - Project Memory
 
 This file contains persistent context for Claude Code sessions on this project.
 It will be automatically loaded at the start of every session.
 
 ## Project Overview
 
-This is the React Native mobile application for AceBack, built with Expo and
+This is the React Native mobile application for Discr, built with Expo and
 powered by Supabase for backend services.
 
 **Key Details:**

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# AceBack Mobile App
+# Discr Mobile App
 
-![GitHub branch status](https://img.shields.io/github/checks-status/acebackapp/mobile/main)
-![GitHub Issues](https://img.shields.io/github/issues/acebackapp/mobile)
-![GitHub last commit](https://img.shields.io/github/last-commit/acebackapp/mobile)
-![GitHub repo size](https://img.shields.io/github/repo-size/acebackapp/mobile)
-![GitHub License](https://img.shields.io/github/license/acebackapp/mobile)
+![GitHub branch status](https://img.shields.io/github/checks-status/discrapp/mobile/main)
+![GitHub Issues](https://img.shields.io/github/issues/discrapp/mobile)
+![GitHub last commit](https://img.shields.io/github/last-commit/discrapp/mobile)
+![GitHub repo size](https://img.shields.io/github/repo-size/discrapp/mobile)
+![GitHub License](https://img.shields.io/github/license/discrapp/mobile)
 
 ## Introduction
 
-AceBack is a mobile-first application built with React Native and Expo,
+Discr is a mobile-first application built with React Native and Expo,
 powered by Supabase for backend services.
 
 ### Key Features
@@ -57,7 +57,7 @@ EOF
    ```
 
 1. Get credentials from the Supabase dashboard:
-   <https://app.supabase.com/project/aceback-mvp/settings/api>
+   <https://app.supabase.com/project/discr-mvp/settings/api>
 
 1. Edit `.env` with your values:
    - `EXPO_PUBLIC_SUPABASE_URL` - Your Supabase project URL

--- a/__tests__/app/order-stickers.test.tsx
+++ b/__tests__/app/order-stickers.test.tsx
@@ -94,7 +94,7 @@ describe('OrderStickersScreen', () => {
       const { getByText } = render(<OrderStickersScreen />);
 
       await waitFor(() => {
-        expect(getByText('AceBack QR Code Stickers')).toBeTruthy();
+        expect(getByText('Discr QR Code Stickers')).toBeTruthy();
       });
     });
 

--- a/__tests__/auth/sign-in.test.tsx
+++ b/__tests__/auth/sign-in.test.tsx
@@ -41,7 +41,7 @@ describe('SignIn', () => {
   it('renders correctly', () => {
     const { getByText, getByPlaceholderText } = render(<SignIn />);
 
-    expect(getByText('AceBack')).toBeTruthy();
+    expect(getByText('Discr')).toBeTruthy();
     expect(getByText('Welcome Back')).toBeTruthy();
     expect(getByText('Sign in to continue')).toBeTruthy();
     expect(getByPlaceholderText('Enter your email')).toBeTruthy();

--- a/__tests__/auth/sign-up.test.tsx
+++ b/__tests__/auth/sign-up.test.tsx
@@ -48,7 +48,7 @@ describe('SignUp', () => {
   it('renders correctly', () => {
     const { getAllByText, getByText, getByPlaceholderText } = render(<SignUp />);
 
-    expect(getByText('AceBack')).toBeTruthy();
+    expect(getByText('Discr')).toBeTruthy();
     expect(getAllByText('Create Account').length).toBeGreaterThanOrEqual(1);
     expect(getByText('Sign up to get started')).toBeTruthy();
     expect(getByPlaceholderText('Enter your email')).toBeTruthy();

--- a/__tests__/lib/deferredLinking.test.ts
+++ b/__tests__/lib/deferredLinking.test.ts
@@ -1,7 +1,7 @@
 import * as Clipboard from 'expo-clipboard';
 
 import {
-  isValidAceBackCode,
+  isValidDiscrCode,
   checkClipboardForCode,
 } from '@/lib/deferredLinking';
 
@@ -16,47 +16,47 @@ describe('deferredLinking', () => {
     jest.clearAllMocks();
   });
 
-  describe('isValidAceBackCode', () => {
+  describe('isValidDiscrCode', () => {
     it('returns true for valid 6-character uppercase code', () => {
-      expect(isValidAceBackCode('ABC123')).toBe(true);
+      expect(isValidDiscrCode('ABC123')).toBe(true);
     });
 
     it('returns true for valid 8-character uppercase code', () => {
-      expect(isValidAceBackCode('ABCD1234')).toBe(true);
+      expect(isValidDiscrCode('ABCD1234')).toBe(true);
     });
 
     it('returns true for valid 7-character code', () => {
-      expect(isValidAceBackCode('ABC1234')).toBe(true);
+      expect(isValidDiscrCode('ABC1234')).toBe(true);
     });
 
     it('converts lowercase to uppercase and validates', () => {
-      expect(isValidAceBackCode('abc123')).toBe(true);
+      expect(isValidDiscrCode('abc123')).toBe(true);
     });
 
     it('returns false for code shorter than 6 characters', () => {
-      expect(isValidAceBackCode('ABC12')).toBe(false);
+      expect(isValidDiscrCode('ABC12')).toBe(false);
     });
 
     it('returns false for code longer than 8 characters', () => {
-      expect(isValidAceBackCode('ABCDE12345')).toBe(false);
+      expect(isValidDiscrCode('ABCDE12345')).toBe(false);
     });
 
     it('returns false for empty string', () => {
-      expect(isValidAceBackCode('')).toBe(false);
+      expect(isValidDiscrCode('')).toBe(false);
     });
 
     it('returns false for null/undefined', () => {
-      expect(isValidAceBackCode(null as unknown as string)).toBe(false);
-      expect(isValidAceBackCode(undefined as unknown as string)).toBe(false);
+      expect(isValidDiscrCode(null as unknown as string)).toBe(false);
+      expect(isValidDiscrCode(undefined as unknown as string)).toBe(false);
     });
 
     it('returns false for code with special characters', () => {
-      expect(isValidAceBackCode('ABC-12')).toBe(false);
-      expect(isValidAceBackCode('ABC_12')).toBe(false);
+      expect(isValidDiscrCode('ABC-12')).toBe(false);
+      expect(isValidDiscrCode('ABC_12')).toBe(false);
     });
 
     it('trims whitespace before validating', () => {
-      expect(isValidAceBackCode('  ABC123  ')).toBe(true);
+      expect(isValidDiscrCode('  ABC123  ')).toBe(true);
     });
   });
 
@@ -87,10 +87,10 @@ describe('deferredLinking', () => {
       expect(result).toBe('ABC123');
     });
 
-    it('extracts code from AceBack URL in clipboard', async () => {
+    it('extracts code from Discr URL in clipboard', async () => {
       (Clipboard.hasStringAsync as jest.Mock).mockResolvedValue(true);
       (Clipboard.getStringAsync as jest.Mock).mockResolvedValue(
-        'https://aceback.app/d/XYZ789'
+        'https://discrapp.com/d/XYZ789'
       );
 
       const result = await checkClipboardForCode();
@@ -101,7 +101,7 @@ describe('deferredLinking', () => {
     it('extracts code from URL with lowercase', async () => {
       (Clipboard.hasStringAsync as jest.Mock).mockResolvedValue(true);
       (Clipboard.getStringAsync as jest.Mock).mockResolvedValue(
-        'https://aceback.app/d/xyz789'
+        'https://discrapp.com/d/xyz789'
       );
 
       const result = await checkClipboardForCode();

--- a/__tests__/tabs/index.test.tsx
+++ b/__tests__/tabs/index.test.tsx
@@ -19,7 +19,7 @@ describe('HomeScreen', () => {
     useAuth.mockReturnValue({ user: null });
     const { getByText } = render(<HomeScreen />);
 
-    expect(getByText('Welcome to AceBack!')).toBeTruthy();
+    expect(getByText('Welcome to Discr!')).toBeTruthy();
     expect(getByText('Never lose your favorite disc again. Track your collection and help others find their lost discs.')).toBeTruthy();
   });
 
@@ -27,7 +27,7 @@ describe('HomeScreen', () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
 
-    expect(getByText('Welcome to AceBack!')).toBeTruthy();
+    expect(getByText('Welcome to Discr!')).toBeTruthy();
     expect(getByText('test@example.com')).toBeTruthy();
   });
 

--- a/app.json
+++ b/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
-    "name": "AceBack",
-    "slug": "aceback",
+    "name": "Discr",
+    "slug": "discr",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "com.aceback.app",
+    "scheme": "com.discr.app",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
@@ -15,11 +15,11 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.aceback.app",
+      "bundleIdentifier": "com.discr.app",
       "config": {
         "usesNonExemptEncryption": false
       },
-      "associatedDomains": ["applinks:aceback.app"],
+      "associatedDomains": ["applinks:discrapp.com"],
       "infoPlist": {
         "LSApplicationQueriesSchemes": ["venmo"]
       },
@@ -34,7 +34,7 @@
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#3b1877"
       },
-      "package": "com.aceback.app",
+      "package": "com.discr.app",
       "intentFilters": [
         {
           "action": "VIEW",
@@ -42,7 +42,7 @@
           "data": [
             {
               "scheme": "https",
-              "host": "aceback.app",
+              "host": "discrapp.com",
               "pathPrefix": "/d/"
             }
           ],

--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -44,7 +44,7 @@ export default function ForgotPassword() {
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(
         email.trim(),
         {
-          redirectTo: 'com.aceback.app://reset-password',
+          redirectTo: 'com.discrapp.com://reset-password',
         }
       );
 
@@ -77,7 +77,7 @@ export default function ForgotPassword() {
     >
       <View style={styles.content}>
         <View style={styles.logoContainer}>
-          <Text style={styles.logo}>AceBack</Text>
+          <Text style={styles.logo}>Discr</Text>
         </View>
 
         <Text style={styles.title}>Reset Password</Text>

--- a/app/(auth)/reset-password.tsx
+++ b/app/(auth)/reset-password.tsx
@@ -80,7 +80,7 @@ export default function ResetPassword() {
     >
       <View style={styles.content}>
         <View style={styles.logoContainer}>
-          <Text style={styles.logo}>AceBack</Text>
+          <Text style={styles.logo}>Discr</Text>
         </View>
 
         <Text style={styles.title}>Create New Password</Text>

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -61,7 +61,7 @@ export default function SignIn() {
     try {
       // Get the correct redirect URL for current environment
       const redirectUrl = AuthSession.makeRedirectUri({
-        scheme: 'com.aceback.app',
+        scheme: 'com.discrapp.com',
       });
 
       console.log('Using redirect URL:', redirectUrl);
@@ -97,7 +97,7 @@ export default function SignIn() {
     >
       <View style={styles.content}>
         <View style={styles.logoContainer}>
-          <Text style={styles.logo}>AceBack</Text>
+          <Text style={styles.logo}>Discr</Text>
         </View>
 
         <Text style={styles.title}>Welcome Back</Text>

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -74,7 +74,7 @@ export default function SignUp() {
     try {
       // Get the correct redirect URL for current environment
       const redirectUrl = AuthSession.makeRedirectUri({
-        scheme: 'com.aceback.app',
+        scheme: 'com.discrapp.com',
       });
 
       console.log('Using redirect URL:', redirectUrl);
@@ -114,7 +114,7 @@ export default function SignUp() {
       >
         <View style={styles.content}>
           <View style={styles.logoContainer}>
-            <Text style={styles.logo}>AceBack</Text>
+            <Text style={styles.logo}>Discr</Text>
           </View>
 
           <Text style={styles.title}>Create Account</Text>

--- a/app/(tabs)/found-disc.tsx
+++ b/app/(tabs)/found-disc.tsx
@@ -266,7 +266,7 @@ export default function FoundDiscScreen() {
     setHasScanned(true);
     let scannedCode = result.data;
 
-    // Extract code from URL if QR contains a URL like https://aceback.app/d/CODE
+    // Extract code from URL if QR contains a URL like https://discrapp.com/d/CODE
     if (scannedCode.includes('/d/')) {
       const match = scannedCode.match(/\/d\/([A-Za-z0-9]+)/);
       if (match) {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -39,7 +39,7 @@ export default function HomeScreen() {
   return (
     <ScrollView style={[styles.scrollView, dynamicStyles.scrollView]} contentContainerStyle={styles.scrollContent}>
       <RNView style={styles.container}>
-        <Text style={styles.title}>Welcome to AceBack!</Text>
+        <Text style={styles.title}>Welcome to Discr!</Text>
         {user && <Text style={[styles.email, dynamicStyles.email]}>{user.email}</Text>}
         <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
         <Text style={[styles.description, dynamicStyles.description]}>

--- a/app/add-disc.tsx
+++ b/app/add-disc.tsx
@@ -147,7 +147,7 @@ export default function AddDiscScreen() {
 
     let scannedCode = result.data;
 
-    // Extract code from URL if QR contains a URL like https://aceback.app/d/CODE
+    // Extract code from URL if QR contains a URL like https://discrapp.com/d/CODE
     if (scannedCode.includes('/d/')) {
       const match = scannedCode.match(/\/d\/([A-Za-z0-9]+)/);
       if (match) {
@@ -502,7 +502,7 @@ export default function AddDiscScreen() {
                     <FontAwesome name="qrcode" size={24} color={Colors.violet.primary} />
                     <View style={styles.qrScanTextContainer}>
                       <Text style={styles.qrScanTitle}>Scan QR Sticker</Text>
-                      <Text style={styles.qrScanSubtitle}>Link an AceBack sticker to this disc</Text>
+                      <Text style={styles.qrScanSubtitle}>Link an Discr sticker to this disc</Text>
                     </View>
                     <FontAwesome name="chevron-right" size={16} color="#999" />
                   </>
@@ -790,7 +790,7 @@ export default function AddDiscScreen() {
             <RNView style={styles.scannerHeader}>
               <Text style={styles.scannerTitle}>Scan QR Sticker</Text>
               <Text style={styles.scannerSubtitle}>
-                Point your camera at an AceBack QR sticker
+                Point your camera at an Discr QR sticker
               </Text>
             </RNView>
             <RNView style={styles.scannerFrame}>

--- a/app/d/[code].tsx
+++ b/app/d/[code].tsx
@@ -7,7 +7,7 @@ import Colors from '@/constants/Colors';
 
 /**
  * Deep link handler for QR code scans.
- * URL format: aceback://d/ABC123 or https://aceback.app/d/ABC123
+ * URL format: com.discr.app://d/ABC123 or https://discrapp.com/d/ABC123
  *
  * This route handles incoming QR code scans from the native camera.
  * It looks up the disc and redirects appropriately:

--- a/app/disc/[id].tsx
+++ b/app/disc/[id].tsx
@@ -270,7 +270,7 @@ export default function DiscDetailScreen() {
     setHasScanned(true);
     let scannedCode = result.data;
 
-    // Extract code from URL if QR contains a URL like https://aceback.app/d/CODE
+    // Extract code from URL if QR contains a URL like https://discrapp.com/d/CODE
     if (scannedCode.includes('/d/')) {
       const match = scannedCode.match(/\/d\/([A-Za-z0-9]+)/);
       if (match) {
@@ -660,7 +660,7 @@ export default function DiscDetailScreen() {
             <RNView style={styles.qrCodeContainer}>
               <RNView style={styles.qrCodeInner}>
                 <QRCode
-                  value={`https://aceback.app/d/${disc.qr_code.short_code}`}
+                  value={`https://discrapp.com/d/${disc.qr_code.short_code}`}
                   size={180}
                   color={Colors.violet.primary}
                   backgroundColor="#fff"

--- a/app/order-stickers.tsx
+++ b/app/order-stickers.tsx
@@ -508,7 +508,7 @@ export default function OrderStickersScreen() {
             <RNView style={[styles.productImageContainer, dynamicStyles.productImageContainer]}>
               <FontAwesome name="qrcode" size={64} color={Colors.violet.primary} />
             </RNView>
-            <Text style={styles.productTitle}>AceBack QR Code Stickers</Text>
+            <Text style={styles.productTitle}>Discr QR Code Stickers</Text>
             <Text style={[styles.productDescription, dynamicStyles.productDescription]}>
               Durable, weatherproof QR stickers. Link to your discs so finders can contact you
               instantly.

--- a/app/orders/[id].tsx
+++ b/app/orders/[id].tsx
@@ -407,9 +407,9 @@ export default function OrderDetailScreen() {
             Need help with your order? Contact us at{' '}
             <Text
               style={styles.helpLink}
-              onPress={() => Linking.openURL('mailto:support@aceback.app')}
+              onPress={() => Linking.openURL('mailto:support@discrapp.com')}
             >
-              support@aceback.app
+              support@discrapp.com
             </Text>
           </Text>
         </RNView>

--- a/contexts/AuthContext.test.tsx
+++ b/contexts/AuthContext.test.tsx
@@ -235,7 +235,7 @@ describe('AuthContext', () => {
       expect(mockSignInWithOAuth).toHaveBeenCalledWith({
         provider: 'google',
         options: {
-          redirectTo: 'com.aceback.app://',
+          redirectTo: 'com.discrapp.com://',
         },
       });
     });

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -226,7 +226,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: 'com.aceback.app://',
+        redirectTo: 'com.discrapp.com://',
       },
     });
     return { error };

--- a/docs/GOOGLE_OAUTH_SETUP.md
+++ b/docs/GOOGLE_OAUTH_SETUP.md
@@ -29,7 +29,7 @@ The app slug is defined in `app.json`:
 
 Go to [Google Cloud Console](https://console.cloud.google.com/apis/credentials):
 
-1. Select your project (`aceback-mvp`)
+1. Select your project (`discr-mvp`)
 1. Go to "Credentials"
 1. Click on your OAuth 2.0 Client ID (`AceBack Web Client`)
 1. Under "Authorized redirect URIs", add:
@@ -37,7 +37,7 @@ Go to [Google Cloud Console](https://console.cloud.google.com/apis/credentials):
    **For Expo Go (Development):**
 
    ```text
-   https://auth.expo.io/@benniemosher-aceback/aceback
+   https://auth.expo.io/@benniemosher-discr/discr
    ```
 
    **For Production (React Native/Expo):**
@@ -46,7 +46,7 @@ Go to [Google Cloud Console](https://console.cloud.google.com/apis/credentials):
    https://xhaogdigrsiwxdjmjzgx.supabase.co/auth/v1/callback
    ```
 
-   This is your Supabase OAuth callback URL. After Google authenticates, it redirects to Supabase, which then redirects back to your app using the custom scheme `com.aceback.app://`.
+   This is your Supabase OAuth callback URL. After Google authenticates, it redirects to Supabase, which then redirects back to your app using the custom scheme `com.discr.app://`.
 
 1. Click "Save"
 
@@ -99,7 +99,7 @@ For standalone builds (not Expo Go):
    ```json
    {
      "expo": {
-       "scheme": "com.aceback.app"
+       "scheme": "com.discr.app"
      }
    }
    ```
@@ -107,7 +107,7 @@ For standalone builds (not Expo Go):
 1. **Update Google Cloud Console redirect URI:**
 
    ```
-   com.aceback.app:/oauthredirect
+   com.discr.app:/oauthredirect
    ```
 
 1. **Configure iOS URL scheme:**
@@ -116,7 +116,7 @@ For standalone builds (not Expo Go):
    {
      "expo": {
        "ios": {
-         "bundleIdentifier": "com.aceback.app",
+         "bundleIdentifier": "com.discr.app",
          "usesAppleSignIn": true
        }
      }
@@ -129,7 +129,7 @@ For standalone builds (not Expo Go):
    {
      "expo": {
        "android": {
-         "package": "com.aceback.app"
+         "package": "com.discr.app"
        }
      }
    }
@@ -147,7 +147,7 @@ import * as WebBrowser from "expo-web-browser";
 WebBrowser.maybeCompleteAuthSession();
 
 const redirectUri = AuthSession.makeRedirectUri({
-  scheme: "com.aceback.app",
+  scheme: "com.discr.app",
 });
 
 // Then use this redirectUri in your OAuth flow

--- a/lib/deferredLinking.ts
+++ b/lib/deferredLinking.ts
@@ -1,19 +1,19 @@
 import * as Clipboard from 'expo-clipboard';
 
-// AceBack QR codes are 6-8 alphanumeric characters
+// Discr QR codes are 6-8 alphanumeric characters
 const CODE_PATTERN = /^[A-Z0-9]{6,8}$/;
 
 /**
- * Check if a string looks like an AceBack QR code
+ * Check if a string looks like a Discr QR code
  */
-export function isValidAceBackCode(text: string): boolean {
+export function isValidDiscrCode(text: string): boolean {
   if (!text) return false;
   const normalized = text.trim().toUpperCase();
   return CODE_PATTERN.test(normalized);
 }
 
 /**
- * Check clipboard for a deferred AceBack code
+ * Check clipboard for a deferred Discr code
  * Returns the code if found and valid, null otherwise
  */
 export async function checkClipboardForCode(): Promise<string | null> {
@@ -27,12 +27,12 @@ export async function checkClipboardForCode(): Promise<string | null> {
     const normalized = clipboardContent.trim().toUpperCase();
 
     // Check if it's a valid code
-    if (isValidAceBackCode(normalized)) {
+    if (isValidDiscrCode(normalized)) {
       return normalized;
     }
 
-    // Also check if clipboard contains an AceBack URL
-    const urlMatch = clipboardContent.match(/aceback\.app\/d\/([A-Za-z0-9]{6,8})/i);
+    // Also check if clipboard contains a Discr URL
+    const urlMatch = clipboardContent.match(/discrapp\.com\/d\/([A-Za-z0-9]{6,8})/i);
     if (urlMatch) {
       return urlMatch[1].toUpperCase();
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aceback/mobile",
+  "name": "@discr/mobile",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "engines": {

--- a/utils/discCache.ts
+++ b/utils/discCache.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-export const DISC_CACHE_KEY = '@aceback/discs_cache';
-export const DISC_CACHE_TIMESTAMP_KEY = '@aceback/discs_cache_timestamp';
+export const DISC_CACHE_KEY = '@discr/discs_cache';
+export const DISC_CACHE_TIMESTAMP_KEY = '@discr/discs_cache_timestamp';
 
 // Cache is considered stale after 30 seconds
 const CACHE_TTL_MS = 30 * 1000;


### PR DESCRIPTION
## Summary
- Rename app from AceBack to Discr throughout the codebase
- Update domain from aceback.app to discrapp.com
- Update bundle identifier, scheme, and package names
- All 487 tests passing

## Changes
- app.json: Updated name, slug, scheme, bundleIdentifier, package, associatedDomains, intentFilters
- lib/deferredLinking.ts: Renamed isValidAceBackCode → isValidDiscrCode, updated URL pattern
- utils/discCache.ts: Updated cache keys from @aceback to @discr
- package.json: Updated package name to @discr/mobile
- All .ts/.tsx files: Replaced AceBack references with Discr
- Documentation: Updated README.md, CLAUDE.md, GOOGLE_OAUTH_SETUP.md

## Manual Changes Required
After merging, the following need manual updates:
- EAS: Update owner from "benniemosher-aceback" to new owner
- Expo project settings
- Apple Developer portal bundle ID
- Google Play package name

## Test plan
- [x] All 487 tests passing
- [ ] Verify deep links work with new domain after DNS setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)