### PR TITLE
feat: add SENTRY_AUTH_TOKEN to production builds for source maps

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -10,7 +10,11 @@
     "preview": {
       "distribution": "internal"
     },
-    "production": {}
+    "production": {
+      "env": {
+        "SENTRY_AUTH_TOKEN": "@sentry-auth-token"
+      }
+    }
   },
   "submit": {
     "production": {}


### PR DESCRIPTION
## Summary
- Added SENTRY_AUTH_TOKEN environment variable to production build config
- Enables source map uploads to Sentry during EAS production builds
- Provides readable stack traces in Sentry dashboard

## Setup Required
After merging, create the EAS secret:
```bash
eas secret:create --scope project --name sentry-auth-token --value <your-token>
```

Get the auth token from Sentry > Settings > Auth Tokens.

## Test plan
- [x] eas.json updated with correct syntax
- [ ] Create EAS secret before next production build
- [ ] Verify source maps upload on next production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)