### PR TITLE
fix: disc autocomplete selection not populating form fields

### DIFF
--- a/app/add-disc.tsx
+++ b/app/add-disc.tsx
@@ -472,7 +472,7 @@ export default function AddDiscScreen() {
         style={[styles.container, dynamicContainerStyle]}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         keyboardVerticalOffset={100}>
-      <ScrollView style={[styles.scrollView, dynamicContainerStyle]} contentContainerStyle={styles.scrollContent}>
+      <ScrollView style={[styles.scrollView, dynamicContainerStyle]} contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
         <View style={styles.form}>
           {/* QR Code Section */}
           <View style={[styles.qrSection, { backgroundColor: isDark ? '#1a1a1a' : '#fff', borderColor: isDark ? '#333' : '#e0e0e0' }]}>


### PR DESCRIPTION
## Summary
- Fixed issue where tapping on disc autocomplete suggestions didn't populate the form fields
- Added `keyboardShouldPersistTaps="handled"` to parent ScrollView

## Root Cause
The parent ScrollView was intercepting taps to dismiss the keyboard before they could reach the autocomplete suggestion items. This caused:
1. Keyboard dismissal
2. Blur event firing (starting to hide suggestions)
3. Tap never reaching the Pressable in the dropdown

## Test plan
- [x] Open add disc screen
- [x] Type "buzzz" in the mold field
- [x] Tap on a suggestion from the dropdown
- [x] Verify manufacturer, flight numbers, and category auto-populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)