### PR TITLE
feat: make add-disc modal transparent

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -169,8 +169,9 @@ function RootLayoutNav() {
           <Stack.Screen
             name="add-disc"
             options={{
-              presentation: 'modal',
+              presentation: 'transparentModal',
               headerShown: false,
+              animation: 'fade',
             }}
           />
           <Stack.Screen

--- a/app/add-disc.tsx
+++ b/app/add-disc.tsx
@@ -624,7 +624,7 @@ export default function AddDiscScreen() {
   };
 
   return (
-    <>
+    <View style={[styles.screenContainer, showOptionsModal && styles.transparentContainer]}>
       {/* Entry Mode Options Modal */}
       <Modal
         visible={showOptionsModal}
@@ -1149,11 +1149,17 @@ export default function AddDiscScreen() {
           </RNView>
         </RNView>
       )}
-    </>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  screenContainer: {
+    flex: 1,
+  },
+  transparentContainer: {
+    backgroundColor: 'transparent',
+  },
   container: {
     flex: 1,
   },


### PR DESCRIPTION
## Summary
- Change presentation from 'modal' to 'transparentModal'
- Add fade animation for smoother transition
- Show My Bag screen through modal when options are displayed

This allows users to see their bag behind the add disc options modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)