### PR TITLE
feat: add Shot Advisor feature with AI-powered shot recommendations

### DIFF
--- a/__tests__/app/shot-recommendation.test.tsx
+++ b/__tests__/app/shot-recommendation.test.tsx
@@ -1,0 +1,356 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import ShotRecommendationScreen from '../../app/shot-recommendation';
+
+// Mock expo-router
+const mockRouterBack = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    back: mockRouterBack,
+  }),
+}));
+
+// Mock supabase
+const mockGetSession = jest.fn();
+jest.mock('../../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: () => mockGetSession(),
+    },
+  },
+}));
+
+// Mock useColorScheme
+jest.mock('../../components/useColorScheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+// Mock CameraWithOverlay
+jest.mock('../../components/CameraWithOverlay', () => 'CameraWithOverlay');
+
+// Mock useShotRecommendation hook
+const mockGetRecommendation = jest.fn();
+const mockReset = jest.fn();
+let mockIsLoading = false;
+let mockError: string | null = null;
+let mockResult: any = null;
+
+jest.mock('../../hooks/useShotRecommendation', () => ({
+  useShotRecommendation: () => ({
+    getRecommendation: mockGetRecommendation,
+    isLoading: mockIsLoading,
+    error: mockError,
+    result: mockResult,
+    reset: mockReset,
+  }),
+}));
+
+// Mock expo-camera
+jest.mock('expo-camera', () => ({
+  useCameraPermissions: () => [{ granted: true }, jest.fn()],
+  CameraView: 'CameraView',
+}));
+
+// Mock Alert
+jest.spyOn(Alert, 'alert');
+
+describe('ShotRecommendationScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsLoading = false;
+    mockError = null;
+    mockResult = null;
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 'test-token' } },
+    });
+  });
+
+  it('renders initial screen with camera prompt', () => {
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText('Shot Advisor')).toBeTruthy();
+    expect(getByText(/Take a photo/i)).toBeTruthy();
+  });
+
+  it('shows loading state while processing', () => {
+    mockIsLoading = true;
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText(/Analyzing/i)).toBeTruthy();
+  });
+
+  it('displays recommendation results', () => {
+    mockResult = {
+      recommendation: {
+        disc: {
+          id: 'disc-1',
+          name: 'Destroyer',
+          manufacturer: 'Innova',
+          flight_numbers: { speed: 12, glide: 5, turn: -1, fade: 3 },
+        },
+        throw_type: 'hyzer',
+        power_percentage: 85,
+        line_description: 'Aim left of center, let disc fade to basket.',
+      },
+      terrain_analysis: {
+        estimated_distance_ft: 285,
+        elevation_change: 'flat',
+        obstacles: 'Tree line on right',
+        fairway_shape: 'straight',
+      },
+      alternatives: [],
+      confidence: 0.85,
+      processing_time_ms: 1200,
+      log_id: 'log-123',
+    };
+
+    const { getByText, getAllByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText('Destroyer')).toBeTruthy();
+    expect(getByText(/285/)).toBeTruthy();
+    // Both confidence (85%) and power (85%) show 85%, so use getAllByText
+    expect(getAllByText(/85%/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('displays throw type in recommendation', () => {
+    mockResult = {
+      recommendation: {
+        disc: { id: 'disc-1', name: 'Destroyer', manufacturer: 'Innova' },
+        throw_type: 'hyzer',
+        power_percentage: 85,
+        line_description: 'Test line description',
+      },
+      terrain_analysis: {
+        estimated_distance_ft: 285,
+        elevation_change: 'flat',
+        obstacles: 'None',
+        fairway_shape: 'straight',
+      },
+      alternatives: [],
+      confidence: 0.85,
+    };
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText(/HYZER/i)).toBeTruthy();
+  });
+
+  it('displays line description', () => {
+    mockResult = {
+      recommendation: {
+        disc: { id: 'disc-1', name: 'Destroyer', manufacturer: 'Innova' },
+        throw_type: 'flat',
+        power_percentage: 90,
+        line_description: 'Throw straight at the basket with full power.',
+      },
+      terrain_analysis: {
+        estimated_distance_ft: 200,
+        elevation_change: 'flat',
+        obstacles: 'None',
+        fairway_shape: 'open',
+      },
+      alternatives: [],
+      confidence: 0.9,
+    };
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText(/Throw straight at the basket/)).toBeTruthy();
+  });
+
+  it('displays alternatives when available', () => {
+    mockResult = {
+      recommendation: {
+        disc: { id: 'disc-1', name: 'Destroyer', manufacturer: 'Innova' },
+        throw_type: 'hyzer',
+        power_percentage: 85,
+        line_description: 'Primary line',
+      },
+      terrain_analysis: {
+        estimated_distance_ft: 285,
+        elevation_change: 'flat',
+        obstacles: 'Trees',
+        fairway_shape: 'straight',
+      },
+      alternatives: [
+        {
+          disc: { id: 'disc-2', name: 'Wraith', manufacturer: 'Innova' },
+          throw_type: 'flat',
+          reason: 'More glide for uphill finish',
+        },
+      ],
+      confidence: 0.85,
+    };
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText('Wraith')).toBeTruthy();
+    expect(getByText(/More glide/)).toBeTruthy();
+  });
+
+  it('displays terrain analysis', () => {
+    mockResult = {
+      recommendation: {
+        disc: { id: 'disc-1', name: 'Destroyer', manufacturer: 'Innova' },
+        throw_type: 'hyzer',
+        power_percentage: 85,
+        line_description: 'Test',
+      },
+      terrain_analysis: {
+        estimated_distance_ft: 350,
+        elevation_change: 'uphill',
+        obstacles: 'OB left, trees right',
+        fairway_shape: 'dogleg_right',
+      },
+      alternatives: [],
+      confidence: 0.75,
+    };
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText(/350/)).toBeTruthy();
+    expect(getByText(/uphill/i)).toBeTruthy();
+  });
+
+  it('shows error message when recommendation fails', () => {
+    mockError = 'No discs in bag. Add discs to get shot recommendations.';
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText(/No discs in bag/)).toBeTruthy();
+  });
+
+  it('shows try again button after error', () => {
+    mockError = 'Something went wrong';
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText('Try Again')).toBeTruthy();
+  });
+
+  it('calls reset when try again is pressed', () => {
+    mockError = 'Something went wrong';
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    fireEvent.press(getByText('Try Again'));
+
+    expect(mockReset).toHaveBeenCalled();
+  });
+
+  it('shows back button', () => {
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    const backButton = getByText('Back');
+    expect(backButton).toBeTruthy();
+  });
+
+  it('navigates back when back button is pressed', () => {
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    fireEvent.press(getByText('Back'));
+
+    expect(mockRouterBack).toHaveBeenCalled();
+  });
+
+  it('shows try another shot button after recommendation', () => {
+    mockResult = {
+      recommendation: {
+        disc: { id: 'disc-1', name: 'Destroyer', manufacturer: 'Innova' },
+        throw_type: 'hyzer',
+        power_percentage: 85,
+        line_description: 'Test',
+      },
+      terrain_analysis: {
+        estimated_distance_ft: 285,
+        elevation_change: 'flat',
+        obstacles: 'None',
+        fairway_shape: 'straight',
+      },
+      alternatives: [],
+      confidence: 0.85,
+    };
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText('Try Another Shot')).toBeTruthy();
+  });
+
+  it('calls reset when try another shot is pressed', () => {
+    mockResult = {
+      recommendation: {
+        disc: { id: 'disc-1', name: 'Destroyer', manufacturer: 'Innova' },
+        throw_type: 'hyzer',
+        power_percentage: 85,
+        line_description: 'Test',
+      },
+      terrain_analysis: {
+        estimated_distance_ft: 285,
+        elevation_change: 'flat',
+        obstacles: 'None',
+        fairway_shape: 'straight',
+      },
+      alternatives: [],
+      confidence: 0.85,
+    };
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    fireEvent.press(getByText('Try Another Shot'));
+
+    expect(mockReset).toHaveBeenCalled();
+  });
+
+  it('displays confidence level', () => {
+    mockResult = {
+      recommendation: {
+        disc: { id: 'disc-1', name: 'Destroyer', manufacturer: 'Innova' },
+        throw_type: 'hyzer',
+        power_percentage: 85,
+        line_description: 'Test',
+      },
+      terrain_analysis: {
+        estimated_distance_ft: 285,
+        elevation_change: 'flat',
+        obstacles: 'None',
+        fairway_shape: 'straight',
+      },
+      alternatives: [],
+      confidence: 0.92,
+    };
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText(/92%/)).toBeTruthy();
+  });
+
+  it('displays flight numbers when available', () => {
+    mockResult = {
+      recommendation: {
+        disc: {
+          id: 'disc-1',
+          name: 'Destroyer',
+          manufacturer: 'Innova',
+          flight_numbers: { speed: 12, glide: 5, turn: -1, fade: 3 },
+        },
+        throw_type: 'hyzer',
+        power_percentage: 85,
+        line_description: 'Test',
+      },
+      terrain_analysis: {
+        estimated_distance_ft: 285,
+        elevation_change: 'flat',
+        obstacles: 'None',
+        fairway_shape: 'straight',
+      },
+      alternatives: [],
+      confidence: 0.85,
+    };
+
+    const { getByText } = render(<ShotRecommendationScreen />);
+
+    expect(getByText(/12/)).toBeTruthy(); // speed
+  });
+});

--- a/__tests__/hooks/useShotRecommendation.test.tsx
+++ b/__tests__/hooks/useShotRecommendation.test.tsx
@@ -1,0 +1,358 @@
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+// Mock Supabase
+const mockGetSession = jest.fn();
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: () => mockGetSession(),
+    },
+  },
+}));
+
+// Mock error handler
+jest.mock('@/lib/errorHandler', () => ({
+  handleError: jest.fn(),
+}));
+
+// Mock fetch
+global.fetch = jest.fn();
+
+import { useShotRecommendation } from '@/hooks/useShotRecommendation';
+import { handleError } from '@/lib/errorHandler';
+
+describe('useShotRecommendation', () => {
+  const mockSession = {
+    access_token: 'test-token',
+    user: { id: 'user-123' },
+  };
+
+  const mockRecommendationResponse = {
+    recommendation: {
+      disc: {
+        id: 'disc-1',
+        name: 'Destroyer',
+        manufacturer: 'Innova',
+        flight_numbers: {
+          speed: 12,
+          glide: 5,
+          turn: -1,
+          fade: 3,
+        },
+      },
+      throw_type: 'hyzer',
+      power_percentage: 85,
+      line_description: 'Aim left of center, let disc fade to basket.',
+    },
+    terrain_analysis: {
+      estimated_distance_ft: 285,
+      elevation_change: 'flat',
+      obstacles: 'Tree line on right',
+      fairway_shape: 'straight',
+    },
+    alternatives: [
+      {
+        disc: { id: 'disc-2', name: 'Wraith', manufacturer: 'Innova' },
+        throw_type: 'flat',
+        reason: 'More glide for uphill finish',
+      },
+    ],
+    confidence: 0.85,
+    processing_time_ms: 1200,
+    log_id: 'log-123',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSession.mockResolvedValue({ data: { session: mockSession } });
+    (global.fetch as jest.Mock).mockReset();
+  });
+
+  it('initializes with default state', () => {
+    const { result } = renderHook(() => useShotRecommendation());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.result).toBeNull();
+  });
+
+  it('returns error when not authenticated', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null } });
+
+    const { result } = renderHook(() => useShotRecommendation());
+
+    await act(async () => {
+      const recommendation = await result.current.getRecommendation('file://test-image.jpg');
+      expect(recommendation).toBeNull();
+    });
+
+    expect(result.current.error).toBe('You must be signed in to get shot recommendations');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('sets loading state during request', async () => {
+    // Create a promise we can control
+    let resolveImageFetch: (value: Response) => void;
+    const imagePromise = new Promise<Response>((resolve) => {
+      resolveImageFetch = resolve;
+    });
+
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(() => imagePromise)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockRecommendationResponse),
+        })
+      );
+
+    const { result } = renderHook(() => useShotRecommendation());
+
+    // Start the request
+    act(() => {
+      result.current.getRecommendation('file://test-image.jpg');
+    });
+
+    // Should be loading
+    expect(result.current.isLoading).toBe(true);
+
+    // Resolve the image fetch
+    await act(async () => {
+      resolveImageFetch!({
+        blob: () => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' })),
+      } as Response);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it('successfully returns recommendation', async () => {
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          blob: () => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' })),
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockRecommendationResponse),
+        })
+      );
+
+    const { result } = renderHook(() => useShotRecommendation());
+
+    let recommendation: typeof mockRecommendationResponse | null = null;
+    await act(async () => {
+      recommendation = await result.current.getRecommendation('file://test-image.jpg');
+    });
+
+    expect(recommendation).toEqual(mockRecommendationResponse);
+    expect(result.current.result).toEqual(mockRecommendationResponse);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('handles API error response', async () => {
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          blob: () => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' })),
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ error: 'No discs in bag' }),
+        })
+      );
+
+    const { result } = renderHook(() => useShotRecommendation());
+
+    await act(async () => {
+      const recommendation = await result.current.getRecommendation('file://test-image.jpg');
+      expect(recommendation).toBeNull();
+    });
+
+    expect(result.current.error).toBe('No discs in bag');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('handles API error with details', async () => {
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          blob: () => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' })),
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: false,
+          status: 502,
+          json: () =>
+            Promise.resolve({
+              error: 'AI recommendation failed',
+              details: 'Claude API returned 500',
+            }),
+        })
+      );
+
+    const { result } = renderHook(() => useShotRecommendation());
+
+    await act(async () => {
+      await result.current.getRecommendation('file://test-image.jpg');
+    });
+
+    expect(result.current.error).toBe('Claude API returned 500');
+  });
+
+  it('handles network errors', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useShotRecommendation());
+
+    await act(async () => {
+      const recommendation = await result.current.getRecommendation('file://test-image.jpg');
+      expect(recommendation).toBeNull();
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(handleError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ operation: 'get-shot-recommendation' })
+    );
+  });
+
+  it('calls correct API endpoint with auth header', async () => {
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          blob: () => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' })),
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockRecommendationResponse),
+        })
+      );
+
+    const { result } = renderHook(() => useShotRecommendation());
+
+    await act(async () => {
+      await result.current.getRecommendation('file://test-image.jpg');
+    });
+
+    // Second call is the API call
+    const apiCall = (global.fetch as jest.Mock).mock.calls[1];
+    expect(apiCall[0]).toContain('/functions/v1/get-shot-recommendation');
+    expect(apiCall[1].method).toBe('POST');
+    expect(apiCall[1].headers.Authorization).toBe('Bearer test-token');
+  });
+
+  it('reset clears all state', async () => {
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          blob: () => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' })),
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockRecommendationResponse),
+        })
+      );
+
+    const { result } = renderHook(() => useShotRecommendation());
+
+    // Get a recommendation first
+    await act(async () => {
+      await result.current.getRecommendation('file://test-image.jpg');
+    });
+
+    expect(result.current.result).not.toBeNull();
+
+    // Reset
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('clears previous result when starting new request', async () => {
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          blob: () => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' })),
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockRecommendationResponse),
+        })
+      );
+
+    const { result } = renderHook(() => useShotRecommendation());
+
+    // First request
+    await act(async () => {
+      await result.current.getRecommendation('file://test-image.jpg');
+    });
+
+    expect(result.current.result).not.toBeNull();
+
+    // Start second request
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          blob: () => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' })),
+        })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise(() => {
+            // Never resolve
+          })
+      );
+
+    act(() => {
+      result.current.getRecommendation('file://another-image.jpg');
+    });
+
+    // Previous result should be cleared while loading
+    expect(result.current.result).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('handles 503 service unavailable', async () => {
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          blob: () => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' })),
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: false,
+          status: 503,
+          json: () => Promise.resolve({ error: 'AI recommendation not configured' }),
+        })
+      );
+
+    const { result } = renderHook(() => useShotRecommendation());
+
+    await act(async () => {
+      await result.current.getRecommendation('file://test-image.jpg');
+    });
+
+    expect(result.current.error).toBe('AI recommendation not configured');
+  });
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -93,6 +93,13 @@ export default function HomeScreen() {
           </RNView>
           <Text style={styles.quickActionText}>Link Sticker</Text>
         </Pressable>
+
+        <Pressable style={[styles.quickAction, dynamicStyles.quickAction]} onPress={() => router.push('/shot-recommendation')}>
+          <RNView style={[styles.quickActionIcon, { backgroundColor: isDark ? 'rgba(139, 92, 246, 0.2)' : Colors.violet[100] }]}>
+            <FontAwesome name="magic" size={20} color={isDark ? '#a78bfa' : Colors.violet.primary} />
+          </RNView>
+          <Text style={styles.quickActionText}>Shot Advisor</Text>
+        </Pressable>
       </RNView>
     </ScrollView>
   );

--- a/app/shot-recommendation.tsx
+++ b/app/shot-recommendation.tsx
@@ -1,0 +1,514 @@
+import { useState, useCallback } from 'react';
+import {
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+  Pressable,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { useCameraPermissions } from 'expo-camera';
+import { Text } from '@/components/Themed';
+import { useColorScheme } from '@/components/useColorScheme';
+import Colors from '@/constants/Colors';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import CameraWithOverlay from '@/components/CameraWithOverlay';
+import { useShotRecommendation } from '@/hooks/useShotRecommendation';
+
+export default function ShotRecommendationScreen() {
+  const router = useRouter();
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+  const textColor = Colors[colorScheme ?? 'light'].text;
+  const [permission, requestPermission] = useCameraPermissions();
+
+  // Camera state
+  const [showCamera, setShowCamera] = useState(false);
+
+  // Shot recommendation hook
+  const { getRecommendation, isLoading, error, result, reset } = useShotRecommendation();
+
+  // Dynamic styles for dark/light mode
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#000' : '#fff',
+    },
+    card: {
+      backgroundColor: isDark ? '#1a1a1a' : '#f8f8f8',
+      borderColor: isDark ? '#333' : '#e0e0e0',
+    },
+    text: {
+      color: textColor,
+    },
+    secondaryText: {
+      color: isDark ? '#999' : '#666',
+    },
+  };
+
+  const handleTakePhoto = async () => {
+    if (!permission?.granted) {
+      const permResult = await requestPermission();
+      if (!permResult.granted) {
+        return;
+      }
+    }
+    setShowCamera(true);
+  };
+
+  const handlePhotoTaken = useCallback(async (uri: string) => {
+    setShowCamera(false);
+    await getRecommendation(uri);
+  }, [getRecommendation]);
+
+  const handleTryAgain = () => {
+    reset();
+  };
+
+  const handleTryAnotherShot = () => {
+    reset();
+  };
+
+  const renderInitialState = () => (
+    <View style={styles.centeredContent}>
+      <View style={[styles.iconContainer, { backgroundColor: 'rgba(127, 34, 206, 0.1)' }]}>
+        <FontAwesome name="camera" size={48} color={Colors.violet.primary} />
+      </View>
+      <Text style={[styles.promptTitle, dynamicStyles.text]}>
+        Take a photo of the hole
+      </Text>
+      <Text style={[styles.promptSubtitle, dynamicStyles.secondaryText]}>
+        Point your camera at the fairway from the tee pad. AI will analyze the
+        terrain and recommend the best disc from your bag.
+      </Text>
+      <Pressable
+        style={[styles.actionButton, { backgroundColor: Colors.violet.primary }]}
+        onPress={handleTakePhoto}
+      >
+        <FontAwesome name="camera" size={20} color="#fff" style={{ marginRight: 8 }} />
+        <Text style={styles.actionButtonText}>Take Photo</Text>
+      </Pressable>
+    </View>
+  );
+
+  const renderLoadingState = () => (
+    <View style={styles.centeredContent}>
+      <ActivityIndicator size="large" color={Colors.violet.primary} />
+      <Text style={[styles.loadingTitle, dynamicStyles.text]}>
+        Analyzing hole...
+      </Text>
+      <Text style={[styles.loadingSubtitle, dynamicStyles.secondaryText]}>
+        AI is estimating distance and selecting the best disc
+      </Text>
+    </View>
+  );
+
+  const renderErrorState = () => (
+    <View style={styles.centeredContent}>
+      <View style={[styles.iconContainer, { backgroundColor: 'rgba(231, 76, 60, 0.1)' }]}>
+        <FontAwesome name="exclamation-triangle" size={48} color="#e74c3c" />
+      </View>
+      <Text style={[styles.errorTitle, dynamicStyles.text]}>
+        Something went wrong
+      </Text>
+      <Text style={[styles.errorMessage, dynamicStyles.secondaryText]}>
+        {error}
+      </Text>
+      <Pressable
+        style={[styles.actionButton, { backgroundColor: Colors.violet.primary }]}
+        onPress={handleTryAgain}
+      >
+        <Text style={styles.actionButtonText}>Try Again</Text>
+      </Pressable>
+    </View>
+  );
+
+  const renderResult = () => {
+    if (!result) return null;
+
+    const { recommendation, terrain_analysis, alternatives, confidence } = result;
+    const disc = recommendation.disc;
+
+    return (
+      <ScrollView
+        style={styles.resultScroll}
+        contentContainerStyle={styles.resultContent}
+      >
+        {/* Terrain Analysis Card */}
+        <View style={[styles.card, dynamicStyles.card]}>
+          <Text style={[styles.cardTitle, dynamicStyles.text]}>Terrain Analysis</Text>
+          <View style={styles.terrainGrid}>
+            <View style={styles.terrainItem}>
+              <Text style={[styles.terrainLabel, dynamicStyles.secondaryText]}>Distance</Text>
+              <Text style={[styles.terrainValue, dynamicStyles.text]}>
+                ~{terrain_analysis.estimated_distance_ft} ft
+              </Text>
+            </View>
+            <View style={styles.terrainItem}>
+              <Text style={[styles.terrainLabel, dynamicStyles.secondaryText]}>Elevation</Text>
+              <Text style={[styles.terrainValue, dynamicStyles.text]}>
+                {terrain_analysis.elevation_change}
+              </Text>
+            </View>
+            <View style={styles.terrainItem}>
+              <Text style={[styles.terrainLabel, dynamicStyles.secondaryText]}>Confidence</Text>
+              <Text style={[styles.terrainValue, dynamicStyles.text]}>
+                {Math.round(confidence * 100)}%
+              </Text>
+            </View>
+          </View>
+          {terrain_analysis.obstacles && terrain_analysis.obstacles !== 'None' && (
+            <View style={styles.obstaclesSection}>
+              <Text style={[styles.obstaclesLabel, dynamicStyles.secondaryText]}>Obstacles</Text>
+              <Text style={[styles.obstaclesValue, dynamicStyles.text]}>
+                {terrain_analysis.obstacles}
+              </Text>
+            </View>
+          )}
+        </View>
+
+        {/* Recommended Shot Card */}
+        <View style={[styles.card, styles.recommendationCard, dynamicStyles.card]}>
+          <Text style={[styles.cardTitle, dynamicStyles.text]}>Recommended Shot</Text>
+
+          {/* Disc Info */}
+          <View style={styles.discSection}>
+            <View style={styles.discInfo}>
+              <Text style={[styles.discName, dynamicStyles.text]}>
+                {disc?.name || 'Unknown Disc'}
+              </Text>
+              {disc?.manufacturer && (
+                <Text style={[styles.discManufacturer, dynamicStyles.secondaryText]}>
+                  {disc.manufacturer}
+                </Text>
+              )}
+              {disc?.flight_numbers && (
+                <Text style={[styles.flightNumbers, { color: Colors.violet.primary }]}>
+                  {disc.flight_numbers.speed} | {disc.flight_numbers.glide} | {disc.flight_numbers.turn} | {disc.flight_numbers.fade}
+                </Text>
+              )}
+            </View>
+          </View>
+
+          {/* Throw Details */}
+          <View style={styles.throwDetails}>
+            <View style={styles.throwItem}>
+              <Text style={[styles.throwLabel, dynamicStyles.secondaryText]}>Throw</Text>
+              <View style={[styles.throwTypeBadge, { backgroundColor: 'rgba(127, 34, 206, 0.1)' }]}>
+                <Text style={[styles.throwTypeText, { color: Colors.violet.primary }]}>
+                  {recommendation.throw_type.toUpperCase()}
+                </Text>
+              </View>
+            </View>
+            <View style={styles.throwItem}>
+              <Text style={[styles.throwLabel, dynamicStyles.secondaryText]}>Power</Text>
+              <Text style={[styles.powerValue, dynamicStyles.text]}>
+                {recommendation.power_percentage}%
+              </Text>
+            </View>
+          </View>
+
+          {/* Line Description */}
+          <View style={styles.lineSection}>
+            <Text style={[styles.lineLabel, dynamicStyles.secondaryText]}>Line</Text>
+            <Text style={[styles.lineDescription, dynamicStyles.text]}>
+              {recommendation.line_description}
+            </Text>
+          </View>
+        </View>
+
+        {/* Alternatives Card */}
+        {alternatives && alternatives.length > 0 && (
+          <View style={[styles.card, dynamicStyles.card]}>
+            <Text style={[styles.cardTitle, dynamicStyles.text]}>Alternatives</Text>
+            {alternatives.map((alt, index) => (
+              <View key={index} style={styles.alternativeItem}>
+                <View style={styles.alternativeHeader}>
+                  <Text style={[styles.alternativeName, dynamicStyles.text]}>
+                    {alt.disc.name || 'Unknown'}
+                  </Text>
+                  <Text style={[styles.alternativeThrow, dynamicStyles.secondaryText]}>
+                    {alt.throw_type}
+                  </Text>
+                </View>
+                <Text style={[styles.alternativeReason, dynamicStyles.secondaryText]}>
+                  {alt.reason}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+
+        {/* Try Another Shot Button */}
+        <Pressable
+          style={[styles.actionButton, styles.tryAnotherButton, { backgroundColor: Colors.violet.primary }]}
+          onPress={handleTryAnotherShot}
+        >
+          <FontAwesome name="camera" size={20} color="#fff" style={{ marginRight: 8 }} />
+          <Text style={styles.actionButtonText}>Try Another Shot</Text>
+        </Pressable>
+      </ScrollView>
+    );
+  };
+
+  return (
+    <View style={[styles.container, dynamicStyles.container]}>
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: isDark ? '#333' : '#e0e0e0' }]}>
+        <Pressable
+          style={styles.backButton}
+          onPress={() => router.back()}
+          hitSlop={8}
+        >
+          <FontAwesome name="chevron-left" size={18} color={textColor} />
+          <Text style={[styles.backText, dynamicStyles.text]}>Back</Text>
+        </Pressable>
+        <Text style={[styles.headerTitle, dynamicStyles.text]}>Shot Advisor</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      {/* Content */}
+      <View style={styles.content}>
+        {isLoading && renderLoadingState()}
+        {!isLoading && error && renderErrorState()}
+        {!isLoading && !error && result && renderResult()}
+        {!isLoading && !error && !result && renderInitialState()}
+      </View>
+
+      {/* Camera Modal */}
+      <CameraWithOverlay
+        visible={showCamera}
+        onClose={() => setShowCamera(false)}
+        onPhotoTaken={handlePhotoTaken}
+        showCircleGuide={false}
+        helperText="Capture the fairway from the tee pad"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  backButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minWidth: 80,
+  },
+  backText: {
+    fontSize: 16,
+    marginLeft: 6,
+  },
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  headerSpacer: {
+    minWidth: 80,
+  },
+  content: {
+    flex: 1,
+  },
+  centeredContent: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 32,
+  },
+  iconContainer: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  promptTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  promptSubtitle: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 32,
+    lineHeight: 24,
+  },
+  loadingTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginTop: 24,
+  },
+  loadingSubtitle: {
+    fontSize: 14,
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  errorTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  errorMessage: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    borderRadius: 12,
+    minWidth: 200,
+  },
+  actionButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  resultScroll: {
+    flex: 1,
+  },
+  resultContent: {
+    padding: 16,
+    paddingBottom: 40,
+  },
+  card: {
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 16,
+    marginBottom: 16,
+  },
+  recommendationCard: {
+    borderColor: Colors.violet.primary,
+    borderWidth: 2,
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+  terrainGrid: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  terrainItem: {
+    alignItems: 'center',
+    flex: 1,
+  },
+  terrainLabel: {
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  terrainValue: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  obstaclesSection: {
+    marginTop: 16,
+    paddingTop: 16,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(128, 128, 128, 0.2)',
+  },
+  obstaclesLabel: {
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  obstaclesValue: {
+    fontSize: 14,
+  },
+  discSection: {
+    marginBottom: 16,
+  },
+  discInfo: {
+    alignItems: 'center',
+  },
+  discName: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  discManufacturer: {
+    fontSize: 14,
+    marginTop: 2,
+  },
+  flightNumbers: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 8,
+  },
+  throwDetails: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginBottom: 16,
+    paddingVertical: 16,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: 'rgba(128, 128, 128, 0.2)',
+  },
+  throwItem: {
+    alignItems: 'center',
+  },
+  throwLabel: {
+    fontSize: 12,
+    marginBottom: 6,
+  },
+  throwTypeBadge: {
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+    borderRadius: 16,
+  },
+  throwTypeText: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  powerValue: {
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  lineSection: {
+    marginTop: 4,
+  },
+  lineLabel: {
+    fontSize: 12,
+    marginBottom: 6,
+  },
+  lineDescription: {
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  alternativeItem: {
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(128, 128, 128, 0.2)',
+  },
+  alternativeHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  alternativeName: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  alternativeThrow: {
+    fontSize: 14,
+  },
+  alternativeReason: {
+    fontSize: 14,
+  },
+  tryAnotherButton: {
+    marginTop: 8,
+  },
+});

--- a/hooks/useShotRecommendation.ts
+++ b/hooks/useShotRecommendation.ts
@@ -1,0 +1,148 @@
+import { useState, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+import { handleError } from '@/lib/errorHandler';
+
+export interface DiscInfo {
+  id: string;
+  name: string | null;
+  manufacturer: string | null;
+  flight_numbers: {
+    speed: number | null;
+    glide: number | null;
+    turn: number | null;
+    fade: number | null;
+  } | null;
+}
+
+export interface ShotRecommendation {
+  disc: DiscInfo | null;
+  throw_type: 'hyzer' | 'flat' | 'anhyzer';
+  power_percentage: number;
+  line_description: string;
+}
+
+export interface TerrainAnalysis {
+  estimated_distance_ft: number;
+  elevation_change: 'uphill' | 'downhill' | 'flat';
+  obstacles: string;
+  fairway_shape: 'straight' | 'dogleg_left' | 'dogleg_right' | 'open';
+}
+
+export interface AlternativeRecommendation {
+  disc: Partial<DiscInfo>;
+  throw_type: string;
+  reason: string;
+}
+
+export interface ShotRecommendationResult {
+  recommendation: ShotRecommendation;
+  terrain_analysis: TerrainAnalysis;
+  alternatives: AlternativeRecommendation[];
+  confidence: number;
+  processing_time_ms: number;
+  log_id: string | null;
+}
+
+interface UseShotRecommendationResult {
+  getRecommendation: (imageUri: string) => Promise<ShotRecommendationResult | null>;
+  isLoading: boolean;
+  error: string | null;
+  result: ShotRecommendationResult | null;
+  reset: () => void;
+}
+
+/**
+ * Hook for getting AI-powered shot recommendations from hole photos.
+ * Calls the get-shot-recommendation edge function.
+ */
+export function useShotRecommendation(): UseShotRecommendationResult {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ShotRecommendationResult | null>(null);
+
+  const reset = useCallback(() => {
+    setIsLoading(false);
+    setError(null);
+    setResult(null);
+  }, []);
+
+  const getRecommendation = useCallback(
+    async (imageUri: string): Promise<ShotRecommendationResult | null> => {
+      setIsLoading(true);
+      setError(null);
+      setResult(null);
+
+      try {
+        // Get session for authentication
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+        if (!session) {
+          setError('You must be signed in to get shot recommendations');
+          return null;
+        }
+
+        // Fetch the image and convert to blob
+        const response = await fetch(imageUri);
+        const blob = await response.blob();
+
+        // Create form data with the image
+        const formData = new FormData();
+        formData.append('image', {
+          uri: imageUri,
+          type: blob.type || 'image/jpeg',
+          name: 'hole-photo.jpg',
+        } as unknown as Blob);
+
+        // Call the get-shot-recommendation endpoint
+        const apiResponse = await fetch(
+          `${process.env.EXPO_PUBLIC_SUPABASE_URL}/functions/v1/get-shot-recommendation`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${session.access_token}`,
+            },
+            body: formData,
+          }
+        );
+
+        const data = await apiResponse.json();
+
+        if (!apiResponse.ok) {
+          const errorMessage = data.details || data.error || 'Failed to get shot recommendation';
+          console.error('Shot recommendation API error:', apiResponse.status, errorMessage, data);
+          setError(errorMessage);
+          return null;
+        }
+
+        const recommendationResult: ShotRecommendationResult = {
+          recommendation: data.recommendation,
+          terrain_analysis: data.terrain_analysis,
+          alternatives: data.alternatives || [],
+          confidence: data.confidence,
+          processing_time_ms: data.processing_time_ms,
+          log_id: data.log_id || null,
+        };
+
+        setResult(recommendationResult);
+        return recommendationResult;
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'An error occurred';
+        setError(errorMessage);
+        handleError(err, { operation: 'get-shot-recommendation' });
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    []
+  );
+
+  return {
+    getRecommendation,
+    isLoading,
+    error,
+    result,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `useShotRecommendation` hook for API integration with the `get-shot-recommendation` edge function
- Add `shot-recommendation` screen with camera capture and results display
- Add Shot Advisor button to home screen quick actions (5th button)
- Shows recommended disc, throw type, power %, and line description
- Includes terrain analysis (distance, elevation, obstacles) and alternative recommendations

## Test plan
- [x] Run `npm test` - all 1373 tests pass
- [ ] Test camera capture flow on device
- [ ] Verify recommendation display with mock API response
- [ ] Test error handling states
- [ ] Verify "Try Again" and "Try Another Shot" buttons work

🤖 Generated with [Claude Code](https://claude.com/claude-code)