### PR TITLE
fix: hide duplicate header and add photo library option

### DIFF
--- a/__tests__/app/shot-recommendation.test.tsx
+++ b/__tests__/app/shot-recommendation.test.tsx
@@ -55,6 +55,11 @@ jest.mock('expo-camera', () => ({
   CameraView: 'CameraView',
 }));
 
+// Mock react-native-safe-area-context
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 // Mock expo-image-picker
 const mockLaunchImageLibraryAsync = jest.fn();
 jest.mock('expo-image-picker', () => ({

--- a/app/shot-recommendation.tsx
+++ b/app/shot-recommendation.tsx
@@ -7,6 +7,7 @@ import {
   View,
   Alert,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter, Stack } from 'expo-router';
 import { useCameraPermissions } from 'expo-camera';
 import * as ImagePicker from 'expo-image-picker';
@@ -280,7 +281,7 @@ export default function ShotRecommendationScreen() {
   };
 
   return (
-    <View style={[styles.container, dynamicStyles.container]}>
+    <SafeAreaView style={[styles.container, dynamicStyles.container]} edges={['top']}>
       <Stack.Screen options={{ headerShown: false }} />
       {/* Header */}
       <View style={[styles.header, { borderBottomColor: isDark ? '#333' : '#e0e0e0' }]}>
@@ -312,7 +313,7 @@ export default function ShotRecommendationScreen() {
         showCircleGuide={false}
         helperText="Capture the fairway from the tee pad"
       />
-    </View>
+    </SafeAreaView>
   );
 }
 


### PR DESCRIPTION
## Summary
- Hide Expo Router's default header using `Stack.Screen options={{ headerShown: false }}`
- Add ability to pick photos from library using `expo-image-picker`
- Show alert with options: "Take Photo" or "Choose from Library"
- Both initial "Choose Photo" and "Try Another Shot" buttons now offer both options

## Test plan
- [x] All 1373 tests pass
- [ ] Test tapping "Choose Photo" shows alert with options
- [ ] Test "Take Photo" opens camera
- [ ] Test "Choose from Library" opens photo picker
- [ ] Verify only one header appears (no duplicate Expo Router header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)