### PR TITLE
feat: display disc photo in recommended shot card

### DIFF
--- a/app/shot-recommendation.tsx
+++ b/app/shot-recommendation.tsx
@@ -6,6 +6,7 @@ import {
   Pressable,
   View,
   Alert,
+  Image,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter, Stack } from 'expo-router';
@@ -199,6 +200,13 @@ export default function ShotRecommendationScreen() {
 
           {/* Disc Info */}
           <View style={styles.discSection}>
+            {disc?.photo_url && (
+              <Image
+                source={{ uri: disc.photo_url }}
+                style={styles.discPhoto}
+                resizeMode="cover"
+              />
+            )}
             <View style={styles.discInfo}>
               <Text style={[styles.discName, dynamicStyles.text]}>
                 {disc?.name || 'Unknown Disc'}
@@ -460,10 +468,19 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   discSection: {
+    flexDirection: 'row',
+    alignItems: 'center',
     marginBottom: 16,
   },
+  discPhoto: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    marginRight: 16,
+  },
   discInfo: {
-    alignItems: 'center',
+    flex: 1,
+    alignItems: 'flex-start',
   },
   discName: {
     fontSize: 24,


### PR DESCRIPTION
## Summary
- Show disc photo (if available) in the recommendation results
- Photo displayed as circular thumbnail next to disc name
- Uses `photo_url` from API response

## Test plan
- [x] All tests pass
- [ ] Test with discs that have photos uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)