### PR TITLE
feat: create reusable DiscAvatar component

### DIFF
--- a/app/(tabs)/my-bag.tsx
+++ b/app/(tabs)/my-bag.tsx
@@ -5,7 +5,6 @@ import {
   FlatList,
   RefreshControl,
   ActivityIndicator,
-  Image,
   View as RNView,
   useColorScheme,
 } from 'react-native';
@@ -17,6 +16,7 @@ import { supabase } from '@/lib/supabase';
 import { getCachedDiscs, setCachedDiscs, isCacheStale } from '@/utils/discCache';
 import { DiscCardSkeleton } from '@/components/Skeleton';
 import { handleError } from '@/lib/errorHandler';
+import DiscAvatar from '@/components/DiscAvatar';
 
 interface FlightNumbers {
   speed: number | null;
@@ -79,21 +79,6 @@ const COLOR_MAP: Record<string, string> = {
   Black: '#2C3E50',
   Gray: '#95A5A6',
   Multi: 'rainbow',
-};
-
-// Two-tone color shades for disc placeholder (lighter, darker)
-const COLOR_SHADES: Record<string, { light: string; dark: string }> = {
-  Red: { light: '#fadbd8', dark: '#c0392b' },
-  Orange: { light: '#fdebd0', dark: '#d35400' },
-  Yellow: { light: '#fcf3cf', dark: '#d4ac0d' },
-  Green: { light: '#d5f5e3', dark: '#1e8449' },
-  Blue: { light: '#d4e6f1', dark: '#2471a3' },
-  Purple: { light: '#e8daef', dark: '#7d3c98' },
-  Pink: { light: '#fadbe8', dark: '#c2185b' },
-  White: { light: '#ffffff', dark: '#ecf0f1' },
-  Black: { light: '#5d6d7e', dark: '#1c2833' },
-  Gray: { light: '#d5d8dc', dark: '#717d7e' },
-  Multi: { light: '#fadbd8', dark: '#d4e6f1' },
 };
 
 export default function MyBagScreen() {
@@ -202,17 +187,7 @@ export default function MyBagScreen() {
         }}>
         {/* Photo */}
         <RNView style={styles.photoContainer}>
-          {firstPhoto?.photo_url ? (
-            <Image source={{ uri: firstPhoto.photo_url }} style={styles.discPhoto} />
-          ) : item.color && COLOR_SHADES[item.color] ? (
-            <RNView style={[styles.twoToneCircle, { backgroundColor: COLOR_SHADES[item.color].light }]}>
-              <RNView style={[styles.twoToneInner, { backgroundColor: COLOR_SHADES[item.color].dark }]} />
-            </RNView>
-          ) : (
-            <RNView style={styles.photoPlaceholder}>
-              <FontAwesome name="circle-o" size={40} color="#555" />
-            </RNView>
-          )}
+          <DiscAvatar photoUrl={firstPhoto?.photo_url} color={item.color} size={60} />
         </RNView>
 
         {/* Disc Info */}
@@ -385,33 +360,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   photoContainer: {
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    overflow: 'hidden',
     marginRight: 12,
-  },
-  discPhoto: {
-    width: '100%',
-    height: '100%',
-  },
-  photoPlaceholder: {
-    width: '100%',
-    height: '100%',
-    backgroundColor: '#1a1a1a',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  twoToneCircle: {
-    width: '100%',
-    height: '100%',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  twoToneInner: {
-    width: '65%',
-    height: '65%',
-    borderRadius: 100,
   },
   discInfo: {
     flex: 1,

--- a/app/shot-recommendation.tsx
+++ b/app/shot-recommendation.tsx
@@ -6,7 +6,6 @@ import {
   Pressable,
   View,
   Alert,
-  Image,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter, Stack } from 'expo-router';
@@ -18,6 +17,7 @@ import Colors from '@/constants/Colors';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import CameraWithOverlay from '@/components/CameraWithOverlay';
 import { useShotRecommendation } from '@/hooks/useShotRecommendation';
+import DiscAvatar from '@/components/DiscAvatar';
 
 export default function ShotRecommendationScreen() {
   const router = useRouter();
@@ -200,13 +200,9 @@ export default function ShotRecommendationScreen() {
 
           {/* Disc Info */}
           <View style={styles.discSection}>
-            {disc?.photo_url && (
-              <Image
-                source={{ uri: disc.photo_url }}
-                style={styles.discPhoto}
-                resizeMode="cover"
-              />
-            )}
+            <View style={styles.discAvatarWrapper}>
+              <DiscAvatar photoUrl={disc?.photo_url} color={disc?.color} size={80} />
+            </View>
             <View style={styles.discInfo}>
               <Text style={[styles.discName, dynamicStyles.text]}>
                 {disc?.name || 'Unknown Disc'}
@@ -472,10 +468,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 16,
   },
-  discPhoto: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
+  discAvatarWrapper: {
     marginRight: 16,
   },
   discInfo: {

--- a/components/DiscAvatar.tsx
+++ b/components/DiscAvatar.tsx
@@ -1,0 +1,97 @@
+import { View, Image, StyleSheet } from 'react-native';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import { useColorScheme } from '@/components/useColorScheme';
+
+// Two-tone color shades for disc placeholder (lighter, darker)
+export const COLOR_SHADES: Record<string, { light: string; dark: string }> = {
+  Red: { light: '#fadbd8', dark: '#c0392b' },
+  Orange: { light: '#fdebd0', dark: '#d35400' },
+  Yellow: { light: '#fcf3cf', dark: '#d4ac0d' },
+  Green: { light: '#d5f5e3', dark: '#1e8449' },
+  Blue: { light: '#d4e6f1', dark: '#2471a3' },
+  Purple: { light: '#e8daef', dark: '#7d3c98' },
+  Pink: { light: '#fadbe8', dark: '#c2185b' },
+  White: { light: '#ffffff', dark: '#ecf0f1' },
+  Black: { light: '#5d6d7e', dark: '#1c2833' },
+  Gray: { light: '#d5d8dc', dark: '#717d7e' },
+  Multi: { light: '#fadbd8', dark: '#d4e6f1' },
+  'Light Blue': { light: '#d6eaf8', dark: '#2e86ab' },
+};
+
+interface DiscAvatarProps {
+  photoUrl?: string | null;
+  color?: string | null;
+  size?: number;
+}
+
+export default function DiscAvatar({ photoUrl, color, size = 60 }: DiscAvatarProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const containerStyle = {
+    width: size,
+    height: size,
+    borderRadius: size / 2,
+  };
+
+  const innerSize = size * 0.65;
+
+  if (photoUrl) {
+    return (
+      <View style={[styles.container, containerStyle]}>
+        <Image source={{ uri: photoUrl }} style={styles.photo} />
+      </View>
+    );
+  }
+
+  if (color && COLOR_SHADES[color]) {
+    return (
+      <View style={[styles.container, containerStyle]}>
+        <View style={[styles.twoToneCircle, { backgroundColor: COLOR_SHADES[color].light }]}>
+          <View
+            style={[
+              styles.twoToneInner,
+              {
+                backgroundColor: COLOR_SHADES[color].dark,
+                width: innerSize,
+                height: innerSize,
+                borderRadius: innerSize / 2,
+              },
+            ]}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, containerStyle]}>
+      <View style={[styles.placeholder, { backgroundColor: isDark ? '#1a1a1a' : '#e0e0e0' }]}>
+        <FontAwesome name="circle-o" size={size * 0.65} color={isDark ? '#555' : '#999'} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    overflow: 'hidden',
+  },
+  photo: {
+    width: '100%',
+    height: '100%',
+  },
+  twoToneCircle: {
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  twoToneInner: {},
+  placeholder: {
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- Create new `DiscAvatar` component that handles disc photo display with fallbacks:
  1. Photo URL (if available)
  2. Two-tone colored circle based on disc color
  3. Gray placeholder circle as final fallback
- Refactor `shot-recommendation.tsx` to use DiscAvatar
- Refactor `my-bag.tsx` to use DiscAvatar (removes duplicate code)

## Test plan
- [x] All 39 tests pass for shot-recommendation and my-bag screens
- [ ] Manual test: Shot Advisor shows colored circle for recommended disc (when no photo)
- [ ] Manual test: My Bag still displays discs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)