### PR TITLE
fix: correct turn direction in flight path overlay

### DIFF
--- a/lib/flightCalculator.ts
+++ b/lib/flightCalculator.ts
@@ -168,8 +168,10 @@ export function calculateRealFlightPath(
   const effectScale = distance / 200;
 
   // Calculate turn and fade effects
-  let turnEffect = turn * 8 * effectScale;
-  let fadeEffect = fade * 12 * effectScale;
+  // Turn is negative for understable discs - negate so negative turn = right curve (positive offset)
+  // Fade is positive for overstable discs - will be subtracted in cp2 to curve left
+  let turnEffect = -turn * 10 * effectScale;
+  let fadeEffect = fade * 15 * effectScale;
 
   // Adjust based on throw type
   switch (throwType) {


### PR DESCRIPTION
## Summary
Turn was curving in the wrong direction. For RHBH:
- Negative turn (understable like -1) should curve RIGHT
- Positive fade should curve LEFT

The issue was that I was using `turn * scale` directly, but negative turn values need to produce a positive (rightward) offset.

## Changes
- Negated turn effect: `-turn * 10 * effectScale`
- Increased scaling factors for more visible curves (10 for turn, 15 for fade)

## Test plan
- [ ] F5 (7/5/-1/1) on hyzer should show slight right curve then fade left
- [ ] Overstable discs should show pronounced left fade
- [ ] Understable discs on anhyzer should show strong right turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)