### PR TITLE
fix: reduce flight path curve intensity for realistic visualization

### DIFF
--- a/lib/flightCalculator.ts
+++ b/lib/flightCalculator.ts
@@ -170,8 +170,9 @@ export function calculateRealFlightPath(
   // Calculate turn and fade effects
   // Turn is negative for understable discs - negate so negative turn = right curve (positive offset)
   // Fade is positive for overstable discs - will be subtracted in cp2 to curve left
-  let turnEffect = -turn * 10 * effectScale;
-  let fadeEffect = fade * 15 * effectScale;
+  // Keep effects subtle - the path should show a realistic flight line, not an exaggerated curve
+  let turnEffect = -turn * 3 * effectScale;
+  let fadeEffect = fade * 4 * effectScale;
 
   // Adjust based on throw type
   switch (throwType) {


### PR DESCRIPTION
## Summary
The flight path curve was too extreme - showing the disc going far left and somehow magically ending at the basket. That's not realistic.

Reduced turn/fade scaling factors from 10/15 to 3/4 for more subtle, realistic flight lines that better represent the actual disc trajectory.

## Test plan
- [ ] H3 V2 (10/5/0/2) on hyzer should show gentle fade left, not extreme curve
- [ ] Path should look like a realistic throw line to the basket

🤖 Generated with [Claude Code](https://claude.com/claude-code)