### PR TITLE
security: Prevent email enumeration in auth error messages

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -21,14 +21,14 @@ const errorMessages: Record<string, string> = {
   'networkerror': 'Unable to connect. Please check your internet.',
   'timeout': 'Request timed out. Please try again.',
 
-  // Auth errors
+  // Auth errors - Use generic messages to prevent email enumeration
   'invalid login credentials': 'Incorrect email or password.',
   'email not confirmed': 'Please verify your email before signing in.',
   'jwt expired': 'Your session has expired. Please sign in again.',
   'jwt malformed': 'Your session has expired. Please sign in again.',
   'refresh_token_not_found': 'Your session has expired. Please sign in again.',
-  'user not found': 'No account found with this email.',
-  'email already registered': 'An account with this email already exists.',
+  'user not found': 'Incorrect email or password.', // Generic to prevent email enumeration
+  'email already registered': 'Unable to create account. Please try again.', // Generic to prevent email enumeration
   'password is too weak': 'Password must be at least 8 characters.',
 
   // API errors


### PR DESCRIPTION
## Summary
- Change "user not found" error to return generic "Incorrect email or password." message
- Change "email already registered" error to return generic "Unable to create account." message

## Why This Matters
Specific error messages like "No account found with this email" allow attackers to:
1. Build a list of valid email addresses
2. Target those emails for phishing
3. Focus brute force attacks on known-valid accounts

## Test plan
- [ ] Sign in with non-existent email - should show "Incorrect email or password."
- [ ] Sign in with wrong password - should show "Incorrect email or password." (same message)
- [ ] Sign up with existing email - should show "Unable to create account."

🤖 Generated with [Claude Code](https://claude.com/claude-code)