### PR TITLE
fix: add dark mode support to auth screens

### DIFF
--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -9,12 +9,15 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  useColorScheme,
 } from 'react-native';
 import { Link, router } from 'expo-router';
 import { supabase } from '@/lib/supabase';
 import Colors from '@/constants/Colors';
 
 export default function ForgotPassword() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
   const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -70,27 +73,48 @@ export default function ForgotPassword() {
     }
   };
 
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#000' : '#fff',
+    },
+    text: {
+      color: isDark ? '#fff' : '#000',
+    },
+    subtitle: {
+      color: isDark ? '#999' : '#666',
+    },
+    input: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : '#ddd',
+      color: isDark ? '#fff' : '#000',
+    },
+    label: {
+      color: isDark ? '#fff' : '#000',
+    },
+  };
+
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      style={styles.container}
+      style={[styles.container, dynamicStyles.container]}
     >
       <View style={styles.content}>
         <View style={styles.logoContainer}>
           <Text style={styles.logo}>Discr</Text>
         </View>
 
-        <Text style={styles.title}>Reset Password</Text>
-        <Text style={styles.subtitle}>
+        <Text style={[styles.title, dynamicStyles.text]}>Reset Password</Text>
+        <Text style={[styles.subtitle, dynamicStyles.subtitle]}>
           Enter your email and we'll send you a link to reset your password.
         </Text>
 
         <View style={styles.form}>
           <View style={styles.inputContainer}>
-            <Text style={styles.label}>Email</Text>
+            <Text style={[styles.label, dynamicStyles.label]}>Email</Text>
             <TextInput
-              style={[styles.input, error ? styles.inputError : null]}
+              style={[styles.input, dynamicStyles.input, error ? styles.inputError : null]}
               placeholder="Enter your email"
+              placeholderTextColor={isDark ? '#666' : '#999'}
               value={email}
               onChangeText={(text) => {
                 setEmail(text);
@@ -133,7 +157,6 @@ export default function ForgotPassword() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
   },
   content: {
     flex: 1,
@@ -154,11 +177,9 @@ const styles = StyleSheet.create({
     fontSize: 32,
     fontWeight: 'bold',
     marginBottom: 8,
-    color: '#000',
   },
   subtitle: {
     fontSize: 16,
-    color: '#666',
     marginBottom: 32,
     lineHeight: 22,
   },
@@ -171,16 +192,12 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#000',
   },
   input: {
     borderWidth: 1,
-    borderColor: '#ddd',
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    backgroundColor: '#fff',
-    color: '#000',
   },
   inputError: {
     borderColor: '#ef4444',

--- a/app/(auth)/reset-password.tsx
+++ b/app/(auth)/reset-password.tsx
@@ -9,12 +9,15 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  useColorScheme,
 } from 'react-native';
 import { router } from 'expo-router';
 import { supabase } from '@/lib/supabase';
 import Colors from '@/constants/Colors';
 
 export default function ResetPassword() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -73,25 +76,46 @@ export default function ResetPassword() {
     }
   };
 
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#000' : '#fff',
+    },
+    text: {
+      color: isDark ? '#fff' : '#000',
+    },
+    subtitle: {
+      color: isDark ? '#999' : '#666',
+    },
+    input: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : '#ddd',
+      color: isDark ? '#fff' : '#000',
+    },
+    label: {
+      color: isDark ? '#fff' : '#000',
+    },
+  };
+
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      style={styles.container}
+      style={[styles.container, dynamicStyles.container]}
     >
       <View style={styles.content}>
         <View style={styles.logoContainer}>
           <Text style={styles.logo}>Discr</Text>
         </View>
 
-        <Text style={styles.title}>Create New Password</Text>
-        <Text style={styles.subtitle}>Enter your new password below.</Text>
+        <Text style={[styles.title, dynamicStyles.text]}>Create New Password</Text>
+        <Text style={[styles.subtitle, dynamicStyles.subtitle]}>Enter your new password below.</Text>
 
         <View style={styles.form}>
           <View style={styles.inputContainer}>
-            <Text style={styles.label}>New Password</Text>
+            <Text style={[styles.label, dynamicStyles.label]}>New Password</Text>
             <TextInput
-              style={[styles.input, errors.password ? styles.inputError : null]}
+              style={[styles.input, dynamicStyles.input, errors.password ? styles.inputError : null]}
               placeholder="Enter new password"
+              placeholderTextColor={isDark ? '#666' : '#999'}
               value={password}
               onChangeText={(text) => {
                 setPassword(text);
@@ -108,13 +132,15 @@ export default function ResetPassword() {
           </View>
 
           <View style={styles.inputContainer}>
-            <Text style={styles.label}>Confirm Password</Text>
+            <Text style={[styles.label, dynamicStyles.label]}>Confirm Password</Text>
             <TextInput
               style={[
                 styles.input,
+                dynamicStyles.input,
                 errors.confirmPassword ? styles.inputError : null,
               ]}
               placeholder="Confirm new password"
+              placeholderTextColor={isDark ? '#666' : '#999'}
               value={confirmPassword}
               onChangeText={(text) => {
                 setConfirmPassword(text);
@@ -150,7 +176,6 @@ export default function ResetPassword() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
   },
   content: {
     flex: 1,
@@ -171,11 +196,9 @@ const styles = StyleSheet.create({
     fontSize: 32,
     fontWeight: 'bold',
     marginBottom: 8,
-    color: '#000',
   },
   subtitle: {
     fontSize: 16,
-    color: '#666',
     marginBottom: 32,
   },
   form: {
@@ -187,16 +210,12 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#000',
   },
   input: {
     borderWidth: 1,
-    borderColor: '#ddd',
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    backgroundColor: '#fff',
-    color: '#000',
   },
   inputError: {
     borderColor: '#ef4444',

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -8,6 +8,7 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  useColorScheme,
 } from 'react-native';
 import { Link, router } from 'expo-router';
 import { useAuth } from '@/contexts/AuthContext';
@@ -16,6 +17,8 @@ import { handleError } from '@/lib/errorHandler';
 import Colors from '@/constants/Colors';
 
 export default function SignIn() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
   const { signIn } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -58,25 +61,49 @@ export default function SignIn() {
     }
   };
 
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#000' : '#fff',
+    },
+    text: {
+      color: isDark ? '#fff' : '#000',
+    },
+    subtitle: {
+      color: isDark ? '#999' : '#666',
+    },
+    input: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : '#ddd',
+      color: isDark ? '#fff' : '#000',
+    },
+    label: {
+      color: isDark ? '#fff' : '#000',
+    },
+    footerText: {
+      color: isDark ? '#999' : '#666',
+    },
+  };
+
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      style={styles.container}
+      style={[styles.container, dynamicStyles.container]}
     >
       <View style={styles.content}>
         <View style={styles.logoContainer}>
           <Text style={styles.logo}>Discr</Text>
         </View>
 
-        <Text style={styles.title}>Welcome Back</Text>
-        <Text style={styles.subtitle}>Sign in to continue</Text>
+        <Text style={[styles.title, dynamicStyles.text]}>Welcome Back</Text>
+        <Text style={[styles.subtitle, dynamicStyles.subtitle]}>Sign in to continue</Text>
 
         <View style={styles.form}>
           <View style={styles.inputContainer}>
-            <Text style={styles.label}>Email</Text>
+            <Text style={[styles.label, dynamicStyles.label]}>Email</Text>
             <TextInput
-              style={[styles.input, errors.email && styles.inputError]}
+              style={[styles.input, dynamicStyles.input, errors.email && styles.inputError]}
               placeholder="Enter your email"
+              placeholderTextColor={isDark ? '#666' : '#999'}
               value={email}
               onChangeText={(text) => {
                 setEmail(text);
@@ -94,10 +121,11 @@ export default function SignIn() {
           </View>
 
           <View style={styles.inputContainer}>
-            <Text style={styles.label}>Password</Text>
+            <Text style={[styles.label, dynamicStyles.label]}>Password</Text>
             <TextInput
-              style={[styles.input, errors.password && styles.inputError]}
+              style={[styles.input, dynamicStyles.input, errors.password && styles.inputError]}
               placeholder="Enter your password"
+              placeholderTextColor={isDark ? '#666' : '#999'}
               value={password}
               onChangeText={(text) => {
                 setPassword(text);
@@ -132,7 +160,7 @@ export default function SignIn() {
           </TouchableOpacity>
 
           <View style={styles.footer}>
-            <Text style={styles.footerText}>Don't have an account? </Text>
+            <Text style={[styles.footerText, dynamicStyles.footerText]}>Don't have an account? </Text>
             <Link href="/(auth)/sign-up" asChild>
               <TouchableOpacity disabled={loading}>
                 <Text style={styles.link}>Sign Up</Text>
@@ -148,7 +176,6 @@ export default function SignIn() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
   },
   content: {
     flex: 1,
@@ -169,11 +196,9 @@ const styles = StyleSheet.create({
     fontSize: 32,
     fontWeight: 'bold',
     marginBottom: 8,
-    color: '#000',
   },
   subtitle: {
     fontSize: 16,
-    color: '#666',
     marginBottom: 32,
   },
   form: {
@@ -185,16 +210,12 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#000',
   },
   input: {
     borderWidth: 1,
-    borderColor: '#ddd',
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    backgroundColor: '#fff',
-    color: '#000',
   },
   inputError: {
     borderColor: '#ef4444',
@@ -235,7 +256,6 @@ const styles = StyleSheet.create({
     marginTop: 16,
   },
   footerText: {
-    color: '#666',
     fontSize: 14,
   },
   link: {

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -10,6 +10,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  useColorScheme,
 } from 'react-native';
 import { Link, router } from 'expo-router';
 import { useAuth } from '@/contexts/AuthContext';
@@ -18,6 +19,8 @@ import { handleError } from '@/lib/errorHandler';
 import Colors from '@/constants/Colors';
 
 export default function SignUp() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
   const { signUp } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -66,10 +69,33 @@ export default function SignUp() {
     }
   };
 
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#000' : '#fff',
+    },
+    text: {
+      color: isDark ? '#fff' : '#000',
+    },
+    subtitle: {
+      color: isDark ? '#999' : '#666',
+    },
+    input: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : '#ddd',
+      color: isDark ? '#fff' : '#000',
+    },
+    label: {
+      color: isDark ? '#fff' : '#000',
+    },
+    footerText: {
+      color: isDark ? '#999' : '#666',
+    },
+  };
+
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      style={styles.container}
+      style={[styles.container, dynamicStyles.container]}
     >
       <ScrollView
         contentContainerStyle={styles.scrollContent}
@@ -80,15 +106,16 @@ export default function SignUp() {
             <Text style={styles.logo}>Discr</Text>
           </View>
 
-          <Text style={styles.title}>Create Account</Text>
-          <Text style={styles.subtitle}>Sign up to get started</Text>
+          <Text style={[styles.title, dynamicStyles.text]}>Create Account</Text>
+          <Text style={[styles.subtitle, dynamicStyles.subtitle]}>Sign up to get started</Text>
 
           <View style={styles.form}>
             <View style={styles.inputContainer}>
-              <Text style={styles.label}>Email</Text>
+              <Text style={[styles.label, dynamicStyles.label]}>Email</Text>
               <TextInput
-                style={[styles.input, errors.email && styles.inputError]}
+                style={[styles.input, dynamicStyles.input, errors.email && styles.inputError]}
                 placeholder="Enter your email"
+                placeholderTextColor={isDark ? '#666' : '#999'}
                 value={email}
                 onChangeText={(text) => {
                   setEmail(text);
@@ -106,10 +133,11 @@ export default function SignUp() {
             </View>
 
             <View style={styles.inputContainer}>
-              <Text style={styles.label}>Password</Text>
+              <Text style={[styles.label, dynamicStyles.label]}>Password</Text>
               <TextInput
-                style={[styles.input, errors.password && styles.inputError]}
+                style={[styles.input, dynamicStyles.input, errors.password && styles.inputError]}
                 placeholder="Create a password (min 8 characters)"
+                placeholderTextColor={isDark ? '#666' : '#999'}
                 value={password}
                 onChangeText={(text) => {
                   setPassword(text);
@@ -126,13 +154,15 @@ export default function SignUp() {
             </View>
 
             <View style={styles.inputContainer}>
-              <Text style={styles.label}>Confirm Password</Text>
+              <Text style={[styles.label, dynamicStyles.label]}>Confirm Password</Text>
               <TextInput
                 style={[
                   styles.input,
+                  dynamicStyles.input,
                   errors.confirmPassword && styles.inputError,
                 ]}
                 placeholder="Confirm your password"
+                placeholderTextColor={isDark ? '#666' : '#999'}
                 value={confirmPassword}
                 onChangeText={(text) => {
                   setConfirmPassword(text);
@@ -161,7 +191,7 @@ export default function SignUp() {
             </TouchableOpacity>
 
             <View style={styles.footer}>
-              <Text style={styles.footerText}>Already have an account? </Text>
+              <Text style={[styles.footerText, dynamicStyles.footerText]}>Already have an account? </Text>
               <Link href="/(auth)/sign-in" asChild>
                 <TouchableOpacity disabled={loading}>
                   <Text style={styles.link}>Sign In</Text>
@@ -178,7 +208,6 @@ export default function SignUp() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
   },
   scrollContent: {
     flexGrow: 1,
@@ -202,11 +231,9 @@ const styles = StyleSheet.create({
     fontSize: 32,
     fontWeight: 'bold',
     marginBottom: 8,
-    color: '#000',
   },
   subtitle: {
     fontSize: 16,
-    color: '#666',
     marginBottom: 32,
   },
   form: {
@@ -218,16 +245,12 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#000',
   },
   input: {
     borderWidth: 1,
-    borderColor: '#ddd',
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    backgroundColor: '#fff',
-    color: '#000',
   },
   inputError: {
     borderColor: '#ef4444',
@@ -258,7 +281,6 @@ const styles = StyleSheet.create({
     marginTop: 16,
   },
   footerText: {
-    color: '#666',
     fontSize: 14,
   },
   link: {


### PR DESCRIPTION
## Summary
- Added proper dark mode support to all authentication screens (sign-in, sign-up, forgot-password, reset-password)
- Implemented useColorScheme hook to detect system theme preference
- Applied dynamic styles for backgrounds, text, inputs, and borders that adapt to light/dark modes
- Preserved brand color (Colors.violet.primary) for buttons and links across both themes

## Test plan
- [ ] Test sign-in screen in light mode - verify white background and dark text
- [ ] Test sign-in screen in dark mode - verify black background and light text
- [ ] Test sign-up screen in light mode
- [ ] Test sign-up screen in dark mode
- [ ] Test forgot-password screen in light mode
- [ ] Test forgot-password screen in dark mode
- [ ] Test reset-password screen in light mode
- [ ] Test reset-password screen in dark mode
- [ ] Verify all text is readable with sufficient contrast in both modes
- [ ] Verify input fields have appropriate backgrounds and borders in both modes
- [ ] Verify brand-colored buttons and links remain consistent across themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)