### PR TITLE
fix: add Sentry error capture to AuthContext OAuth flow

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -123,6 +123,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       })
       .catch((error) => {
         console.error('Failed to get session:', error);
+        captureError(error, { operation: 'getSession' });
         setLoading(false);
       });
 
@@ -168,12 +169,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
             if (error) {
               console.error('OAuth error:', error);
+              captureError(error, {
+                operation: 'oauthCallback',
+                hasAccessToken: !!accessToken,
+                hasRefreshToken: !!refreshToken,
+              });
             } else {
               console.log('Session set successfully');
             }
           }
         } catch (err) {
           console.error('Error parsing deep link:', err);
+          captureError(err as Error, {
+            operation: 'deepLinkParsing',
+            url: event.url,
+          });
         }
       }
     };
@@ -225,6 +235,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       email,
       password,
     });
+    if (error) {
+      captureError(error, { operation: 'signIn', email });
+    }
     return { error };
   };
 
@@ -233,6 +246,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       email,
       password,
     });
+    if (error) {
+      captureError(error, { operation: 'signUp', email });
+    }
     return { error };
   };
 
@@ -243,6 +259,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         redirectTo: 'com.discr.app://',
       },
     });
+    if (error) {
+      captureError(error, { operation: 'signInWithGoogle', provider: 'google' });
+    }
     return { error };
   };
 


### PR DESCRIPTION
## Summary

- Add Sentry error capture to signIn and signUp failures with email context
- Add Sentry error capture to signInWithGoogle failures with provider context  
- Add Sentry error capture to OAuth deep link session failures
- Add Sentry error capture to deep link URL parsing errors
- Add Sentry error capture to getSession initialization failures

## Test plan

- [x] Tests written first following TDD
- [x] 9 new tests added covering all error capture scenarios
- [x] Verify errors are not captured on successful operations
- [x] All 49 AuthContext tests pass
- [x] Full test suite passes (1765 tests, pre-existing failures unrelated to this change)

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)