### PR TITLE
fix: add dark mode support to claim-disc screen (#199)

### DIFF
--- a/__tests__/claim-disc.test.tsx
+++ b/__tests__/claim-disc.test.tsx
@@ -23,6 +23,12 @@ jest.mock('expo-router', () => ({
   useLocalSearchParams: () => mockSearchParams,
 }));
 
+// Mock useColorScheme - default to light mode
+let mockColorScheme: 'light' | 'dark' = 'light';
+jest.mock('../components/useColorScheme', () => ({
+  useColorScheme: () => mockColorScheme,
+}));
+
 // Mock auth context
 let mockUser: { id: string; email: string } | null = { id: 'user-123', email: 'test@test.com' };
 jest.mock('../contexts/AuthContext', () => ({
@@ -156,6 +162,219 @@ describe('ClaimDiscScreen', () => {
     await waitFor(() => {
       const indicators = UNSAFE_getAllByType(ActivityIndicator);
       expect(indicators.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('dark mode', () => {
+    beforeEach(() => {
+      mockColorScheme = 'dark';
+    });
+
+    afterEach(() => {
+      mockColorScheme = 'light';
+    });
+
+    it('renders with dark mode styles', () => {
+      const { getByText, UNSAFE_root } = render(<ClaimDiscScreen />);
+
+      // Verify screen renders in dark mode
+      expect(getByText('Claim Disc')).toBeTruthy();
+
+      // Find ScrollView (container) and check it has dark background
+      const scrollView = UNSAFE_root.findByType(
+        require('react-native').ScrollView
+      );
+      const containerStyle = scrollView.props.style;
+
+      // Check for dark background color - style can be an array
+      const flatStyle = Array.isArray(containerStyle)
+        ? Object.assign({}, ...containerStyle)
+        : containerStyle;
+      expect(flatStyle.backgroundColor).toBe('#000');
+    });
+
+    it('applies dark mode styles to header', () => {
+      const { UNSAFE_root } = render(<ClaimDiscScreen />);
+
+      // Find all Views and look for header with dark background
+      const views = UNSAFE_root.findAllByType(require('react-native').View);
+
+      // Header should have dark background (#000 or #1a1a1a)
+      const headerView = views.find((view) => {
+        const style = view.props.style;
+        if (Array.isArray(style)) {
+          return style.some(
+            (s) => s?.backgroundColor === '#000' || s?.backgroundColor === '#1a1a1a'
+          );
+        }
+        return (
+          style?.backgroundColor === '#000' ||
+          style?.backgroundColor === '#1a1a1a'
+        );
+      });
+      expect(headerView).toBeTruthy();
+    });
+
+    it('applies dark mode styles to text elements', () => {
+      const { getByText } = render(<ClaimDiscScreen />);
+
+      // Header title should have light text in dark mode
+      const headerTitle = getByText('Claim Disc');
+      const style = headerTitle.props.style;
+
+      // Check for light text color (#fff or #ccc)
+      const flatStyle = Array.isArray(style)
+        ? Object.assign({}, ...style)
+        : style;
+      expect(['#fff', '#ccc', '#e0e0e0']).toContain(flatStyle.color);
+    });
+
+    it('applies dark mode styles to info card', () => {
+      const { UNSAFE_root } = render(<ClaimDiscScreen />);
+
+      const views = UNSAFE_root.findAllByType(require('react-native').View);
+
+      // Info card should have dark background
+      const infoCardView = views.find((view) => {
+        const style = view.props.style;
+        if (Array.isArray(style)) {
+          return style.some((s) => s?.backgroundColor === '#1a1a1a');
+        }
+        return style?.backgroundColor === '#1a1a1a';
+      });
+      expect(infoCardView).toBeTruthy();
+    });
+
+    it('applies dark mode styles to info row borders', () => {
+      const { UNSAFE_root } = render(<ClaimDiscScreen />);
+
+      const views = UNSAFE_root.findAllByType(require('react-native').View);
+
+      // Info rows should have dark border color (#333)
+      const infoRowView = views.find((view) => {
+        const style = view.props.style;
+        if (Array.isArray(style)) {
+          return style.some((s) => s?.borderBottomColor === '#333');
+        }
+        return style?.borderBottomColor === '#333';
+      });
+      expect(infoRowView).toBeTruthy();
+    });
+
+    it('applies dark mode styles to photo container', () => {
+      const { UNSAFE_root } = render(<ClaimDiscScreen />);
+
+      const views = UNSAFE_root.findAllByType(require('react-native').View);
+
+      // Photo container should have dark background
+      const photoContainerView = views.find((view) => {
+        const style = view.props.style;
+        if (Array.isArray(style)) {
+          return style.some(
+            (s) =>
+              s?.backgroundColor === '#000' || s?.backgroundColor === '#1a1a1a'
+          );
+        }
+        return (
+          style?.backgroundColor === '#000' ||
+          style?.backgroundColor === '#1a1a1a'
+        );
+      });
+      expect(photoContainerView).toBeTruthy();
+    });
+  });
+
+  describe('light mode', () => {
+    beforeEach(() => {
+      mockColorScheme = 'light';
+    });
+
+    it('renders with light mode styles', () => {
+      const { getByText, UNSAFE_root } = render(<ClaimDiscScreen />);
+
+      // Verify screen renders in light mode
+      expect(getByText('Claim Disc')).toBeTruthy();
+
+      // Find ScrollView (container) and check it has light background
+      const scrollView = UNSAFE_root.findByType(
+        require('react-native').ScrollView
+      );
+      const containerStyle = scrollView.props.style;
+
+      // Check for light background color - style can be an array
+      const flatStyle = Array.isArray(containerStyle)
+        ? Object.assign({}, ...containerStyle)
+        : containerStyle;
+      expect(flatStyle.backgroundColor).toBe('#f5f5f5');
+    });
+
+    it('applies light mode styles to header', () => {
+      const { UNSAFE_root } = render(<ClaimDiscScreen />);
+
+      const views = UNSAFE_root.findAllByType(require('react-native').View);
+
+      // Header should have light background (#fff)
+      const headerView = views.find((view) => {
+        const style = view.props.style;
+        if (Array.isArray(style)) {
+          return style.some((s) => s?.backgroundColor === '#fff');
+        }
+        return style?.backgroundColor === '#fff';
+      });
+      expect(headerView).toBeTruthy();
+    });
+
+    it('applies light mode styles to text elements', () => {
+      const { getByText } = render(<ClaimDiscScreen />);
+
+      // Header title should have dark text in light mode
+      const headerTitle = getByText('Claim Disc');
+      const style = headerTitle.props.style;
+
+      // Check for dark text color (#333)
+      const flatStyle = Array.isArray(style)
+        ? Object.assign({}, ...style)
+        : style;
+      expect(flatStyle.color).toBe('#333');
+    });
+
+    it('applies light mode styles to info card', () => {
+      const { UNSAFE_root } = render(<ClaimDiscScreen />);
+
+      const views = UNSAFE_root.findAllByType(require('react-native').View);
+
+      // Info card should have light background (#fff)
+      const infoCardView = views.find((view) => {
+        const style = view.props.style;
+        if (Array.isArray(style)) {
+          return style.some((s) => s?.backgroundColor === '#fff');
+        }
+        return style?.backgroundColor === '#fff';
+      });
+      expect(infoCardView).toBeTruthy();
+    });
+
+    it('applies light mode styles to info row borders', () => {
+      const { UNSAFE_root } = render(<ClaimDiscScreen />);
+
+      const views = UNSAFE_root.findAllByType(require('react-native').View);
+
+      // Info rows should have light border color (#f0f0f0 or #eee)
+      const infoRowView = views.find((view) => {
+        const style = view.props.style;
+        if (Array.isArray(style)) {
+          return style.some(
+            (s) =>
+              s?.borderBottomColor === '#f0f0f0' ||
+              s?.borderBottomColor === '#eee'
+          );
+        }
+        return (
+          style?.borderBottomColor === '#f0f0f0' ||
+          style?.borderBottomColor === '#eee'
+        );
+      });
+      expect(infoRowView).toBeTruthy();
     });
   });
 });

--- a/app/claim-disc.tsx
+++ b/app/claim-disc.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/lib/supabase';
 import Colors from '@/constants/Colors';
 import { handleError, showSuccess } from '@/lib/errorHandler';
+import { useColorScheme } from '@/components/useColorScheme';
 
 /**
  * Claim Disc Screen
@@ -25,6 +26,8 @@ import { handleError, showSuccess } from '@/lib/errorHandler';
 export default function ClaimDiscScreen() {
   const router = useRouter();
   const { user } = useAuth();
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
   const params = useLocalSearchParams<{
     discId: string;
     discName: string;
@@ -36,6 +39,46 @@ export default function ClaimDiscScreen() {
   }>();
 
   const [claiming, setClaiming] = useState(false);
+
+  // Dynamic styles for dark/light mode
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#000' : '#f5f5f5',
+    },
+    header: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+    },
+    headerTitle: {
+      color: isDark ? '#fff' : '#333',
+    },
+    photoContainer: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+    },
+    placeholderPhoto: {
+      backgroundColor: isDark ? '#333' : '#f0f0f0',
+    },
+    infoCard: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+    },
+    discName: {
+      color: isDark ? '#fff' : '#333',
+    },
+    infoRow: {
+      borderBottomColor: isDark ? '#333' : '#f0f0f0',
+    },
+    infoLabel: {
+      color: isDark ? '#999' : '#666',
+    },
+    infoValue: {
+      color: isDark ? '#ccc' : '#333',
+    },
+    claimBannerSubtitle: {
+      color: isDark ? '#999' : '#666',
+    },
+    skipButtonText: {
+      color: isDark ? '#999' : '#666',
+    },
+  };
 
   // istanbul ignore next -- Claim flow tested via integration tests
   const handleClaimDisc = async () => {
@@ -97,56 +140,61 @@ export default function ClaimDiscScreen() {
   const handleBack = () => router.back();
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+    <ScrollView
+      style={[styles.container, dynamicStyles.container]}
+      contentContainerStyle={styles.content}
+    >
       {/* Header */}
-      <View style={styles.header}>
+      <View style={[styles.header, dynamicStyles.header]}>
         <Pressable style={styles.backButton} onPress={handleBack}>
           <FontAwesome name="chevron-left" size={20} color={Colors.violet.primary} />
         </Pressable>
-        <Text style={styles.headerTitle}>Claim Disc</Text>
+        <Text style={[styles.headerTitle, dynamicStyles.headerTitle]}>Claim Disc</Text>
         <View style={styles.backButton} />
       </View>
 
       {/* Disc Photo */}
-      <View style={styles.photoContainer}>
+      <View style={[styles.photoContainer, dynamicStyles.photoContainer]}>
         {params.discPhotoUrl ? (
           <Image source={{ uri: params.discPhotoUrl }} style={styles.photo} />
         ) : (
-          <View style={styles.placeholderPhoto}>
-            <FontAwesome name="circle" size={80} color="#ccc" />
+          <View style={[styles.placeholderPhoto, dynamicStyles.placeholderPhoto]}>
+            <FontAwesome name="circle" size={80} color={isDark ? '#666' : '#ccc'} />
           </View>
         )}
       </View>
 
       {/* Disc Info */}
-      <View style={styles.infoCard}>
-        <Text style={styles.discName}>{discName}</Text>
+      <View style={[styles.infoCard, dynamicStyles.infoCard]}>
+        <Text style={[styles.discName, dynamicStyles.discName]}>{discName}</Text>
 
         {params.discManufacturer && (
-          <View style={styles.infoRow}>
-            <Text style={styles.infoLabel}>Manufacturer</Text>
-            <Text style={styles.infoValue}>{params.discManufacturer}</Text>
+          <View style={[styles.infoRow, dynamicStyles.infoRow]}>
+            <Text style={[styles.infoLabel, dynamicStyles.infoLabel]}>Manufacturer</Text>
+            <Text style={[styles.infoValue, dynamicStyles.infoValue]}>
+              {params.discManufacturer}
+            </Text>
           </View>
         )}
 
         {params.discMold && (
-          <View style={styles.infoRow}>
-            <Text style={styles.infoLabel}>Mold</Text>
-            <Text style={styles.infoValue}>{params.discMold}</Text>
+          <View style={[styles.infoRow, dynamicStyles.infoRow]}>
+            <Text style={[styles.infoLabel, dynamicStyles.infoLabel]}>Mold</Text>
+            <Text style={[styles.infoValue, dynamicStyles.infoValue]}>{params.discMold}</Text>
           </View>
         )}
 
         {params.discPlastic && (
-          <View style={styles.infoRow}>
-            <Text style={styles.infoLabel}>Plastic</Text>
-            <Text style={styles.infoValue}>{params.discPlastic}</Text>
+          <View style={[styles.infoRow, dynamicStyles.infoRow]}>
+            <Text style={[styles.infoLabel, dynamicStyles.infoLabel]}>Plastic</Text>
+            <Text style={[styles.infoValue, dynamicStyles.infoValue]}>{params.discPlastic}</Text>
           </View>
         )}
 
         {params.discColor && (
-          <View style={styles.infoRow}>
-            <Text style={styles.infoLabel}>Color</Text>
-            <Text style={styles.infoValue}>{params.discColor}</Text>
+          <View style={[styles.infoRow, dynamicStyles.infoRow]}>
+            <Text style={[styles.infoLabel, dynamicStyles.infoLabel]}>Color</Text>
+            <Text style={[styles.infoValue, dynamicStyles.infoValue]}>{params.discColor}</Text>
           </View>
         )}
       </View>
@@ -156,7 +204,7 @@ export default function ClaimDiscScreen() {
         <FontAwesome name="gift" size={24} color={Colors.violet.primary} />
         <View style={styles.claimBannerText}>
           <Text style={styles.claimBannerTitle}>Available to Claim!</Text>
-          <Text style={styles.claimBannerSubtitle}>
+          <Text style={[styles.claimBannerSubtitle, dynamicStyles.claimBannerSubtitle]}>
             This disc has been abandoned by its previous owner. You can claim it
             and add it to your collection.
           </Text>
@@ -181,7 +229,9 @@ export default function ClaimDiscScreen() {
 
       {/* Skip Link */}
       <Pressable style={styles.skipButton} onPress={() => router.replace('/(tabs)')}>
-        <Text style={styles.skipButtonText}>No thanks, go to home</Text>
+        <Text style={[styles.skipButtonText, dynamicStyles.skipButtonText]}>
+          No thanks, go to home
+        </Text>
       </Pressable>
     </ScrollView>
   );


### PR DESCRIPTION
## Summary
- Added `useColorScheme` hook to detect system dark/light mode preference
- Created dynamic styles object with conditional colors for dark/light mode
- Applied dark mode styling to all UI elements: container, header, photo container, info card, info rows, text elements, and skip button

Fixes #199

## Test plan
- [x] Run `npm test -- --testPathPattern="claim-disc"` - 20 tests pass
- [ ] Manually verify in iOS simulator with light mode
- [ ] Manually verify in iOS simulator with dark mode
- [ ] Verify text is readable in both modes
- [ ] Verify info card borders are visible in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)