### PR TITLE
refactor: extract duplicated COLOR_MAP to shared constants (#201)

### DIFF
--- a/__tests__/constants/discColors.test.ts
+++ b/__tests__/constants/discColors.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for disc color constants
+ *
+ * These tests ensure disc color mappings are centralized and have expected values.
+ * Following TDD principles - these tests are written BEFORE implementation.
+ */
+
+import { DISC_COLORS, DiscColorName } from '@/constants/discColors';
+
+describe('DISC_COLORS constants', () => {
+  describe('structure', () => {
+    it('should export DISC_COLORS object', () => {
+      expect(DISC_COLORS).toBeDefined();
+      expect(typeof DISC_COLORS).toBe('object');
+    });
+
+    it('should be immutable (frozen)', () => {
+      expect(Object.isFrozen(DISC_COLORS)).toBe(true);
+    });
+
+    it('should have all expected color keys', () => {
+      const expectedColors: DiscColorName[] = [
+        'Red',
+        'Orange',
+        'Yellow',
+        'Green',
+        'Blue',
+        'Purple',
+        'Pink',
+        'White',
+        'Black',
+        'Gray',
+        'Multi',
+      ];
+
+      expectedColors.forEach((color) => {
+        expect(DISC_COLORS[color]).toBeDefined();
+      });
+    });
+
+    it('should have exactly 11 colors', () => {
+      expect(Object.keys(DISC_COLORS)).toHaveLength(11);
+    });
+  });
+
+  describe('color values', () => {
+    it('should have correct hex value for Red', () => {
+      expect(DISC_COLORS.Red).toBe('#E74C3C');
+    });
+
+    it('should have correct hex value for Orange', () => {
+      expect(DISC_COLORS.Orange).toBe('#E67E22');
+    });
+
+    it('should have correct hex value for Yellow', () => {
+      expect(DISC_COLORS.Yellow).toBe('#F1C40F');
+    });
+
+    it('should have correct hex value for Green', () => {
+      expect(DISC_COLORS.Green).toBe('#2ECC71');
+    });
+
+    it('should have correct hex value for Blue', () => {
+      expect(DISC_COLORS.Blue).toBe('#3498DB');
+    });
+
+    it('should have correct hex value for Purple', () => {
+      expect(DISC_COLORS.Purple).toBe('#9B59B6');
+    });
+
+    it('should have correct hex value for Pink', () => {
+      expect(DISC_COLORS.Pink).toBe('#E91E63');
+    });
+
+    it('should have correct hex value for White', () => {
+      expect(DISC_COLORS.White).toBe('#ECF0F1');
+    });
+
+    it('should have correct hex value for Black', () => {
+      expect(DISC_COLORS.Black).toBe('#2C3E50');
+    });
+
+    it('should have correct hex value for Gray', () => {
+      expect(DISC_COLORS.Gray).toBe('#95A5A6');
+    });
+
+    it('should have "rainbow" value for Multi', () => {
+      expect(DISC_COLORS.Multi).toBe('rainbow');
+    });
+  });
+
+  describe('type safety', () => {
+    it('should allow accessing colors by string key', () => {
+      const colorName = 'Blue' as DiscColorName;
+      expect(DISC_COLORS[colorName]).toBe('#3498DB');
+    });
+
+    it('should return undefined for unknown colors when accessed with string', () => {
+      // This tests runtime behavior when an unknown color is passed
+      const unknownColor = 'Unknown' as string;
+      expect((DISC_COLORS as Record<string, string>)[unknownColor]).toBeUndefined();
+    });
+  });
+});

--- a/app/(tabs)/found-disc.tsx
+++ b/app/(tabs)/found-disc.tsx
@@ -19,27 +19,13 @@ import { CameraView, useCameraPermissions, BarcodeScanningResult } from 'expo-ca
 import { Text, View } from '@/components/Themed';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import Colors from '@/constants/Colors';
+import { DISC_COLORS } from '@/constants/discColors';
 import { supabase } from '@/lib/supabase';
 import { useColorScheme } from '@/components/useColorScheme';
 import { RecoveryCardSkeleton } from '@/components/Skeleton';
 import { handleError } from '@/lib/errorHandler';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
-
-// Color mapping with hex values
-const COLOR_MAP: Record<string, string> = {
-  Red: '#E74C3C',
-  Orange: '#E67E22',
-  Yellow: '#F1C40F',
-  Green: '#2ECC71',
-  Blue: '#3498DB',
-  Purple: '#9B59B6',
-  Pink: '#E91E63',
-  White: '#ECF0F1',
-  Black: '#2C3E50',
-  Gray: '#95A5A6',
-  Multi: 'rainbow',
-};
 
 type ScreenState = 'input' | 'scanning' | 'loading' | 'found' | 'reporting' | 'success' | 'error' | 'qr_claim' | 'qr_link' | 'claiming' | 'claim_success';
 
@@ -845,7 +831,7 @@ export default function FoundDiscScreen() {
             {discInfo.plastic && <Text style={styles.discPlastic}>{discInfo.plastic}</Text>}
             {discInfo.color && (
               <View style={styles.colorBadge}>
-                {COLOR_MAP[discInfo.color] === 'rainbow' ? (
+                {DISC_COLORS[discInfo.color as keyof typeof DISC_COLORS] === 'rainbow' ? (
                   <View style={styles.rainbowDot}>
                     <View style={[styles.rainbowSlice, { backgroundColor: '#E74C3C' }]} />
                     <View style={[styles.rainbowSlice, { backgroundColor: '#F1C40F' }]} />
@@ -857,7 +843,7 @@ export default function FoundDiscScreen() {
                     style={[
                       styles.colorDot,
                       {
-                        backgroundColor: COLOR_MAP[discInfo.color] || '#666',
+                        backgroundColor: DISC_COLORS[discInfo.color as keyof typeof DISC_COLORS] || '#666',
                         borderColor: discInfo.color === 'White' ? '#ccc' : 'rgba(0, 0, 0, 0.1)',
                       },
                     ]}

--- a/app/(tabs)/my-bag.tsx
+++ b/app/(tabs)/my-bag.tsx
@@ -12,6 +12,7 @@ import { useRouter, useFocusEffect } from 'expo-router';
 import { Text, View } from '@/components/Themed';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import Colors from '@/constants/Colors';
+import { DISC_COLORS } from '@/constants/discColors';
 import { supabase } from '@/lib/supabase';
 import { getCachedDiscs, setCachedDiscs, isCacheStale } from '@/utils/discCache';
 import { DiscCardSkeleton } from '@/components/Skeleton';
@@ -64,21 +65,6 @@ const RECOVERY_STATUS_MAP: Record<string, { label: string; color: string }> = {
   found: { label: 'Found', color: '#F39C12' },
   meetup_proposed: { label: 'Meetup Proposed', color: '#3498DB' },
   meetup_confirmed: { label: 'Meetup Confirmed', color: '#27AE60' },
-};
-
-// Color mapping with hex values
-const COLOR_MAP: Record<string, string> = {
-  Red: '#E74C3C',
-  Orange: '#E67E22',
-  Yellow: '#F1C40F',
-  Green: '#2ECC71',
-  Blue: '#3498DB',
-  Purple: '#9B59B6',
-  Pink: '#E91E63',
-  White: '#ECF0F1',
-  Black: '#2C3E50',
-  Gray: '#95A5A6',
-  Multi: 'rainbow',
 };
 
 export default function MyBagScreen() {
@@ -219,7 +205,7 @@ export default function MyBagScreen() {
           <View style={styles.discFooter}>
             {item.color && (
               <View style={styles.colorBadge}>
-                {COLOR_MAP[item.color] === 'rainbow' ? (
+                {DISC_COLORS[item.color as keyof typeof DISC_COLORS] === 'rainbow' ? (
                   <View style={styles.rainbowDot}>
                     <View style={[styles.rainbowSlice, { backgroundColor: '#E74C3C' }]} />
                     <View style={[styles.rainbowSlice, { backgroundColor: '#F1C40F' }]} />
@@ -231,7 +217,7 @@ export default function MyBagScreen() {
                     style={[
                       styles.colorDot,
                       {
-                        backgroundColor: COLOR_MAP[item.color] || '#666',
+                        backgroundColor: DISC_COLORS[item.color as keyof typeof DISC_COLORS] || '#666',
                         borderColor:
                           item.color === 'White' ? '#ccc' : 'rgba(0, 0, 0, 0.1)',
                       },

--- a/app/disc/[id].tsx
+++ b/app/disc/[id].tsx
@@ -17,6 +17,7 @@ import { Text, View } from '@/components/Themed';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import QRCode from 'react-native-qrcode-svg';
 import Colors from '@/constants/Colors';
+import { DISC_COLORS } from '@/constants/discColors';
 import { supabase } from '@/lib/supabase';
 import { useColorScheme } from '@/components/useColorScheme';
 import { DiscDetailSkeleton } from '@/components/Skeleton';
@@ -82,21 +83,6 @@ interface Disc {
   surrendered_at?: string | null;
   ai_identification_log_id?: string | null;
 }
-
-// Color mapping with hex values
-const COLOR_MAP: Record<string, string> = {
-  Red: '#E74C3C',
-  Orange: '#E67E22',
-  Yellow: '#F1C40F',
-  Green: '#2ECC71',
-  Blue: '#3498DB',
-  Purple: '#9B59B6',
-  Pink: '#E91E63',
-  White: '#ECF0F1',
-  Black: '#2C3E50',
-  Gray: '#95A5A6',
-  Multi: 'rainbow',
-};
 
 export default function DiscDetailScreen() {
   const router = useRouter();
@@ -600,7 +586,7 @@ export default function DiscDetailScreen() {
             <View style={styles.detailItem}>
               <Text style={styles.detailLabel}>Color</Text>
               <View style={styles.colorValue}>
-                {COLOR_MAP[disc.color] === 'rainbow' ? (
+                {DISC_COLORS[disc.color as keyof typeof DISC_COLORS] === 'rainbow' ? (
                   <View style={styles.rainbowDot}>
                     <View style={[styles.rainbowSlice, { backgroundColor: '#E74C3C' }]} />
                     <View style={[styles.rainbowSlice, { backgroundColor: '#F1C40F' }]} />
@@ -612,7 +598,7 @@ export default function DiscDetailScreen() {
                     style={[
                       styles.colorDot,
                       {
-                        backgroundColor: COLOR_MAP[disc.color] || '#666',
+                        backgroundColor: DISC_COLORS[disc.color as keyof typeof DISC_COLORS] || '#666',
                         borderColor: disc.color === 'White' ? '#ccc' : 'rgba(0, 0, 0, 0.1)',
                       },
                     ]}

--- a/constants/discColors.ts
+++ b/constants/discColors.ts
@@ -1,0 +1,67 @@
+/**
+ * Centralized disc color constants for the Discr mobile app.
+ *
+ * This file contains the color mapping for disc colors used throughout the app.
+ * Benefits:
+ * - Single source of truth for disc color hex values
+ * - Type-safe color name access
+ * - Consistent color display across all screens
+ *
+ * Usage:
+ * ```typescript
+ * import { DISC_COLORS, DiscColorName } from '@/constants/discColors';
+ *
+ * // Use with a known color
+ * const redHex = DISC_COLORS.Red; // '#E74C3C'
+ *
+ * // Use with a dynamic color name
+ * const color: DiscColorName = 'Blue';
+ * const hex = DISC_COLORS[color]; // '#3498DB'
+ *
+ * // Check for rainbow/multi color
+ * if (DISC_COLORS[color] === 'rainbow') {
+ *   // Render gradient
+ * }
+ * ```
+ */
+
+/**
+ * Valid disc color names
+ */
+export type DiscColorName =
+  | 'Red'
+  | 'Orange'
+  | 'Yellow'
+  | 'Green'
+  | 'Blue'
+  | 'Purple'
+  | 'Pink'
+  | 'White'
+  | 'Black'
+  | 'Gray'
+  | 'Multi';
+
+/**
+ * Mapping of disc color names to their hex values.
+ * 'Multi' maps to 'rainbow' which indicates a gradient should be used.
+ */
+const _DISC_COLORS: Record<DiscColorName, string> = {
+  Red: '#E74C3C',
+  Orange: '#E67E22',
+  Yellow: '#F1C40F',
+  Green: '#2ECC71',
+  Blue: '#3498DB',
+  Purple: '#9B59B6',
+  Pink: '#E91E63',
+  White: '#ECF0F1',
+  Black: '#2C3E50',
+  Gray: '#95A5A6',
+  Multi: 'rainbow',
+};
+
+/**
+ * Frozen disc color mapping for immutability.
+ * Use this constant to get hex values for disc colors.
+ */
+export const DISC_COLORS: Readonly<Record<DiscColorName, string>> =
+  Object.freeze(_DISC_COLORS);


### PR DESCRIPTION
## Summary
- Create a new shared constant `DISC_COLORS` in `constants/discColors.ts` to replace duplicated `COLOR_MAP` definitions
- Add TypeScript types (`DiscColorName`) for type-safe color access
- Remove duplicate `COLOR_MAP` definitions from 3 files and update to use the shared constant
- Add comprehensive tests for the new constant following TDD practices

Closes #201

## Test plan
- [x] All existing tests pass (`npm test`)
- [x] New tests added for `DISC_COLORS` constant structure and values
- [x] Verified color display still works in my-bag, found-disc, and disc detail screens
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)