### PR TITLE
fix: compress images before upload in shot analyzer

### DIFF
--- a/__tests__/hooks/useShotRecommendation.test.tsx
+++ b/__tests__/hooks/useShotRecommendation.test.tsx
@@ -15,6 +15,17 @@ jest.mock('@/lib/errorHandler', () => ({
   handleError: jest.fn(),
 }));
 
+// Mock image compression
+jest.mock('@/utils/imageCompression', () => ({
+  compressImage: jest.fn((uri: string) =>
+    Promise.resolve({
+      uri: `compressed-${uri}`,
+      width: 1600,
+      height: 1200,
+    })
+  ),
+}));
+
 // Mock fetch
 global.fetch = jest.fn();
 


### PR DESCRIPTION
## Summary
- Fixes the "File size must be less than 5MB" error when using the shot analyzer with large photos
- Uses the existing `compressImage` utility that was already in the codebase but not being used

## Changes
- Import and call `compressImage` in `useShotRecommendation.ts` before uploading
- Compress to 1600px max dimension and 70% JPEG quality
- This ensures photos stay well under the 5MB API limit
- Added mock for `compressImage` in tests

## Test plan
- [x] All 1852 tests pass
- [ ] Test with large photos from camera that previously failed
- [ ] Verify shot analyzer works with compressed images

🤖 Generated with [Claude Code](https://claude.com/claude-code)