### PR TITLE
feat: add useDiscRecommendations hook for Fill the Bag feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,15 @@ useProtectedRoute checks user state
 └─ Authenticated → /(tabs)
 ```
 
+## Cross-Repository Updates
+
+When adding new user-facing features, consider updating the web landing page:
+
+- **Web App** (`web/`): Announce new features on the landing page
+  - Update feature highlights section for major new capabilities
+  - Add screenshots or descriptions of new functionality
+  - Ensure marketing copy reflects current app capabilities
+
 ## References
 
 - @README.md - Repository overview
@@ -358,7 +367,7 @@ useProtectedRoute checks user state
 
 ---
 
-**Last Updated:** 2025-12-19
+**Last Updated:** 2026-01-02
 
 This file should be updated whenever:
 

--- a/__tests__/hooks/useDiscRecommendations.test.tsx
+++ b/__tests__/hooks/useDiscRecommendations.test.tsx
@@ -1,0 +1,418 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+// Mock Supabase
+const mockGetSession = jest.fn();
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: () => mockGetSession(),
+    },
+  },
+}));
+
+// Mock error handler
+jest.mock('@/lib/errorHandler', () => ({
+  handleError: jest.fn(),
+}));
+
+// Mock fetch
+global.fetch = jest.fn();
+
+import { useDiscRecommendations } from '@/hooks/useDiscRecommendations';
+import { handleError } from '@/lib/errorHandler';
+
+describe('useDiscRecommendations', () => {
+  const mockSession = {
+    access_token: 'test-token',
+    user: { id: 'user-123' },
+  };
+
+  const mockRecommendationResponse = {
+    recommendations: [
+      {
+        disc: {
+          id: 'catalog-1',
+          manufacturer: 'Innova',
+          mold: 'Leopard',
+          category: 'Fairway Driver',
+          flight_numbers: {
+            speed: 6,
+            glide: 5,
+            turn: -2,
+            fade: 1,
+          },
+          stability: 'Understable',
+        },
+        reason: 'Your bag lacks an understable fairway driver for turnover shots.',
+        gap_type: 'stability',
+        priority: 1,
+        purchase_url: 'https://infinitediscs.com/search?s=Innova%20Leopard&aff=test',
+      },
+    ],
+    bag_analysis: {
+      total_discs: 5,
+      brand_preferences: [
+        { manufacturer: 'Innova', count: 3 },
+        { manufacturer: 'Discraft', count: 2 },
+      ],
+      plastic_preferences: [
+        { plastic: 'Star', count: 3 },
+        { plastic: 'Z', count: 2 },
+      ],
+      speed_coverage: {
+        min: 5,
+        max: 12,
+        gaps: [],
+      },
+      stability_by_category: [
+        { category: 'Distance Driver', understable: 0, stable: 1, overstable: 1 },
+        { category: 'Midrange', understable: 1, stable: 1, overstable: 0 },
+      ],
+      identified_gaps: ['No understable Fairway Driver'],
+    },
+    confidence: 0.85,
+    processing_time_ms: 1500,
+    log_id: 'log-123',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSession.mockResolvedValue({ data: { session: mockSession } });
+    (global.fetch as jest.Mock).mockReset();
+  });
+
+  it('initializes with default state', () => {
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.result).toBeNull();
+  });
+
+  it('returns error when not authenticated', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null } });
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      const recommendations = await result.current.getRecommendations(1);
+      expect(recommendations).toBeNull();
+    });
+
+    expect(result.current.error).toBe('You must be signed in to get recommendations');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('sets loading state during request', async () => {
+    let resolveRequest: (value: Response) => void;
+    const requestPromise = new Promise<Response>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    (global.fetch as jest.Mock).mockImplementationOnce(() => requestPromise);
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    // Start the request
+    act(() => {
+      result.current.getRecommendations(1);
+    });
+
+    // Should be loading
+    expect(result.current.isLoading).toBe(true);
+
+    // Resolve the request
+    await act(async () => {
+      resolveRequest!({
+        ok: true,
+        json: () => Promise.resolve(mockRecommendationResponse),
+      } as Response);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('successfully returns 1 recommendation', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockRecommendationResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      const recommendations = await result.current.getRecommendations(1);
+      expect(recommendations).not.toBeNull();
+    });
+
+    expect(result.current.result).toEqual(mockRecommendationResponse);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('successfully returns 3 recommendations', async () => {
+    const threeRecResponse = {
+      ...mockRecommendationResponse,
+      recommendations: [
+        mockRecommendationResponse.recommendations[0],
+        { ...mockRecommendationResponse.recommendations[0], priority: 2 },
+        { ...mockRecommendationResponse.recommendations[0], priority: 3 },
+      ],
+    };
+
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(threeRecResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      await result.current.getRecommendations(3);
+    });
+
+    expect(result.current.result?.recommendations).toHaveLength(3);
+  });
+
+  it('successfully returns 5 recommendations', async () => {
+    const fiveRecResponse = {
+      ...mockRecommendationResponse,
+      recommendations: Array(5)
+        .fill(null)
+        .map((_, i) => ({
+          ...mockRecommendationResponse.recommendations[0],
+          priority: i + 1,
+        })),
+    };
+
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(fiveRecResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      await result.current.getRecommendations(5);
+    });
+
+    expect(result.current.result?.recommendations).toHaveLength(5);
+  });
+
+  it('handles API error response', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: 'No discs in bag. Add discs to get recommendations.' }),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      const recommendations = await result.current.getRecommendations(1);
+      expect(recommendations).toBeNull();
+    });
+
+    expect(result.current.error).toBe('No discs in bag. Add discs to get recommendations.');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('handles API error with details', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        status: 502,
+        json: () =>
+          Promise.resolve({
+            error: 'AI recommendations failed',
+            details: 'Claude API returned 500',
+          }),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      await result.current.getRecommendations(1);
+    });
+
+    expect(result.current.error).toBe('Claude API returned 500');
+  });
+
+  it('handles network errors', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      const recommendations = await result.current.getRecommendations(1);
+      expect(recommendations).toBeNull();
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(handleError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ operation: 'get-disc-recommendations' })
+    );
+  });
+
+  it('calls correct API endpoint with auth header and count', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockRecommendationResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      await result.current.getRecommendations(3);
+    });
+
+    const apiCall = (global.fetch as jest.Mock).mock.calls[0];
+    expect(apiCall[0]).toContain('/functions/v1/get-disc-recommendations');
+    expect(apiCall[1].method).toBe('POST');
+    expect(apiCall[1].headers.Authorization).toBe('Bearer test-token');
+    expect(apiCall[1].headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(apiCall[1].body)).toEqual({ count: 3 });
+  });
+
+  it('reset clears all state', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockRecommendationResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    // Get recommendations first
+    await act(async () => {
+      await result.current.getRecommendations(1);
+    });
+
+    expect(result.current.result).not.toBeNull();
+
+    // Reset
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('clears previous result when starting new request', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockRecommendationResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    // First request
+    await act(async () => {
+      await result.current.getRecommendations(1);
+    });
+
+    expect(result.current.result).not.toBeNull();
+
+    // Start second request (never resolve)
+    (global.fetch as jest.Mock).mockImplementationOnce(() => new Promise(() => {}));
+
+    act(() => {
+      result.current.getRecommendations(3);
+    });
+
+    // Previous result should be cleared while loading
+    expect(result.current.result).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('handles 503 service unavailable', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({ error: 'AI recommendations not configured' }),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      await result.current.getRecommendations(1);
+    });
+
+    expect(result.current.error).toBe('AI recommendations not configured');
+  });
+
+  it('includes bag_analysis in result', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockRecommendationResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      await result.current.getRecommendations(1);
+    });
+
+    expect(result.current.result?.bag_analysis).toBeDefined();
+    expect(result.current.result?.bag_analysis.total_discs).toBe(5);
+    expect(result.current.result?.bag_analysis.brand_preferences).toHaveLength(2);
+    expect(result.current.result?.bag_analysis.identified_gaps).toContain('No understable Fairway Driver');
+  });
+
+  it('includes purchase_url in recommendations', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockRecommendationResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      await result.current.getRecommendations(1);
+    });
+
+    expect(result.current.result?.recommendations[0].purchase_url).toContain('infinitediscs.com');
+  });
+
+  it('includes confidence and processing_time_ms in result', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockRecommendationResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDiscRecommendations());
+
+    await act(async () => {
+      await result.current.getRecommendations(1);
+    });
+
+    expect(result.current.result?.confidence).toBe(0.85);
+    expect(result.current.result?.processing_time_ms).toBe(1500);
+    expect(result.current.result?.log_id).toBe('log-123');
+  });
+});

--- a/hooks/useDiscRecommendations.ts
+++ b/hooks/useDiscRecommendations.ts
@@ -1,0 +1,162 @@
+import { useState, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+import { handleError } from '@/lib/errorHandler';
+
+export interface FlightNumbers {
+  speed: number;
+  glide: number;
+  turn: number;
+  fade: number;
+}
+
+export interface RecommendedDisc {
+  id: string;
+  manufacturer: string;
+  mold: string;
+  category: string | null;
+  flight_numbers: FlightNumbers | null;
+  stability: string | null;
+}
+
+export interface DiscRecommendation {
+  disc: RecommendedDisc;
+  reason: string;
+  gap_type: 'speed_range' | 'stability' | 'category';
+  priority: number;
+  purchase_url: string;
+}
+
+export interface BrandPreference {
+  manufacturer: string;
+  count: number;
+}
+
+export interface PlasticPreference {
+  plastic: string;
+  count: number;
+}
+
+export interface SpeedGap {
+  from: number;
+  to: number;
+}
+
+export interface StabilityByCategory {
+  category: string;
+  understable: number;
+  stable: number;
+  overstable: number;
+}
+
+export interface BagAnalysis {
+  total_discs: number;
+  brand_preferences: BrandPreference[];
+  plastic_preferences: PlasticPreference[];
+  speed_coverage: {
+    min: number;
+    max: number;
+    gaps: SpeedGap[];
+  };
+  stability_by_category: StabilityByCategory[];
+  identified_gaps: string[];
+}
+
+export interface DiscRecommendationResult {
+  recommendations: DiscRecommendation[];
+  bag_analysis: BagAnalysis;
+  confidence: number;
+  processing_time_ms: number;
+  log_id: string | null;
+}
+
+interface UseDiscRecommendationsResult {
+  getRecommendations: (count: 1 | 3 | 5) => Promise<DiscRecommendationResult | null>;
+  isLoading: boolean;
+  error: string | null;
+  result: DiscRecommendationResult | null;
+  reset: () => void;
+}
+
+/**
+ * Hook for getting AI-powered disc recommendations to fill bag gaps.
+ * Calls the get-disc-recommendations edge function.
+ */
+export function useDiscRecommendations(): UseDiscRecommendationsResult {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<DiscRecommendationResult | null>(null);
+
+  const reset = useCallback(() => {
+    setIsLoading(false);
+    setError(null);
+    setResult(null);
+  }, []);
+
+  const getRecommendations = useCallback(
+    async (count: 1 | 3 | 5): Promise<DiscRecommendationResult | null> => {
+      setIsLoading(true);
+      setError(null);
+      setResult(null);
+
+      try {
+        // Get session for authentication
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+        if (!session) {
+          setError('You must be signed in to get recommendations');
+          return null;
+        }
+
+        // Call the get-disc-recommendations endpoint
+        const response = await fetch(
+          `${process.env.EXPO_PUBLIC_SUPABASE_URL}/functions/v1/get-disc-recommendations`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${session.access_token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ count }),
+          }
+        );
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          const errorMessage = data.details || data.error || 'Failed to get recommendations';
+          console.error('Disc recommendations API error:', response.status, errorMessage, data);
+          setError(errorMessage);
+          return null;
+        }
+
+        const recommendationResult: DiscRecommendationResult = {
+          recommendations: data.recommendations,
+          bag_analysis: data.bag_analysis,
+          confidence: data.confidence,
+          processing_time_ms: data.processing_time_ms,
+          log_id: data.log_id || null,
+        };
+
+        setResult(recommendationResult);
+        return recommendationResult;
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'An error occurred';
+        setError(errorMessage);
+        handleError(err, { operation: 'get-disc-recommendations' });
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    []
+  );
+
+  return {
+    getRecommendations,
+    isLoading,
+    error,
+    result,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary

Implements the mobile hook for the AI-powered "Fill the Bag" feature that analyzes a user's disc bag and recommends discs to fill gaps.

- Add `useDiscRecommendations` hook with loading/error/result state management
- Supports requesting 1, 3, or 5 disc recommendations
- Returns comprehensive bag analysis (brand/plastic preferences, speed gaps, stability by category)
- Includes affiliate purchase URLs for recommended discs
- 16 tests covering auth, API calls, error handling, and state management

## Hook API

```typescript
const { 
  getRecommendations, 
  isLoading, 
  error, 
  result, 
  reset 
} = useDiscRecommendations();

// Request recommendations
const data = await getRecommendations(3); // 1, 3, or 5

// Result includes:
// - recommendations: DiscRecommendation[]
// - bag_analysis: BagAnalysis
// - confidence: number
// - processing_time_ms: number
// - log_id: string | null
```

## Types Exported

- `DiscRecommendation` - Individual disc recommendation with purchase URL
- `BagAnalysis` - Analysis of user's current bag
- `FlightNumbers`, `BrandPreference`, `PlasticPreference`, etc.

## Test Plan

- [x] 16 unit tests passing
- [x] Follows existing hook patterns (useShotRecommendation)
- [ ] Integration test with real API (after API PR merged)

## Related

- Requires: discrapp/api#250 (API endpoint)
- Related to: discrapp/api#249 (PR 2 of 5)
- Next: PR 3 will add UI components and navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)