### PR TITLE
feat: add bag stats dashboard to home page

### DIFF
--- a/__tests__/tabs/index.test.tsx
+++ b/__tests__/tabs/index.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import HomeScreen from '../../app/(tabs)/index';
 
 // Mock useAuth
-const mockUser = { email: 'test@example.com' };
+const mockUser = { email: 'test@example.com', id: 'user-123' };
 jest.mock('../../contexts/AuthContext', () => ({
   useAuth: jest.fn(() => ({ user: null })),
 }));
@@ -12,116 +12,225 @@ jest.mock('../../contexts/AuthContext', () => ({
 const mockPush = jest.fn();
 jest.mock('expo-router', () => ({
   useRouter: () => ({ push: mockPush }),
+  useFocusEffect: jest.fn(),
+}));
+
+// Mock supabase
+jest.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => Promise.resolve({ data: [], error: null })),
+      })),
+    })),
+  },
+}));
+
+// Mock disc cache
+jest.mock('../../utils/discCache', () => ({
+  getCachedDiscs: jest.fn(() => Promise.resolve(null)),
+  CachedDisc: {},
+}));
+
+// Mock logger
+jest.mock('../../lib/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
 }));
 
 const { useAuth } = require('../../contexts/AuthContext');
+const { getCachedDiscs } = require('../../utils/discCache');
 
 describe('HomeScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    getCachedDiscs.mockResolvedValue(null);
   });
 
-  it('renders welcome message', () => {
+  it('renders welcome message', async () => {
     useAuth.mockReturnValue({ user: null });
     const { getByText } = render(<HomeScreen />);
 
-    expect(getByText('Welcome to Discr!')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('Welcome to Discr!')).toBeTruthy();
+    });
     expect(getByText('Never lose your favorite disc again. Track your collection and help others find their lost discs.')).toBeTruthy();
   });
 
-  it('displays user email when logged in', () => {
+  it('displays user email when logged in', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
 
-    expect(getByText('Welcome to Discr!')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('Welcome to Discr!')).toBeTruthy();
+    });
     expect(getByText('test@example.com')).toBeTruthy();
   });
 
-  it('does not display email when not logged in', () => {
+  it('does not display email when not logged in', async () => {
     useAuth.mockReturnValue({ user: null });
     const { queryByText } = render(<HomeScreen />);
 
-    expect(queryByText('test@example.com')).toBeNull();
+    await waitFor(() => {
+      expect(queryByText('test@example.com')).toBeNull();
+    });
   });
 
-  it('shows order stickers card', () => {
+  it('shows order stickers card', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
 
-    expect(getByText('Protect Your Discs')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('Protect Your Discs')).toBeTruthy();
+    });
     expect(getByText(/Get QR code stickers/)).toBeTruthy();
   });
 
-  it('navigates to order stickers when card is pressed', () => {
+  it('navigates to order stickers when card is pressed', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Protect Your Discs')).toBeTruthy();
+    });
 
     fireEvent.press(getByText('Protect Your Discs'));
 
     expect(mockPush).toHaveBeenCalledWith('/order-stickers');
   });
 
-  it('shows Add Disc quick action', () => {
+  it('shows Add Disc quick action', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
 
-    expect(getByText('Add Disc')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('Add Disc')).toBeTruthy();
+    });
   });
 
-  it('navigates to add-disc when pressed', () => {
+  it('navigates to add-disc when pressed', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Add Disc')).toBeTruthy();
+    });
 
     fireEvent.press(getByText('Add Disc'));
 
     expect(mockPush).toHaveBeenCalledWith('/add-disc');
   });
 
-  it('shows My Orders quick action', () => {
+  it('shows My Orders quick action', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
 
-    expect(getByText('My Orders')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('My Orders')).toBeTruthy();
+    });
   });
 
-  it('navigates to my-orders when pressed', () => {
+  it('navigates to my-orders when pressed', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
+
+    await waitFor(() => {
+      expect(getByText('My Orders')).toBeTruthy();
+    });
 
     fireEvent.press(getByText('My Orders'));
 
     expect(mockPush).toHaveBeenCalledWith('/my-orders');
   });
 
-  it('shows Found Disc quick action', () => {
+  it('shows Found Disc quick action', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
 
-    expect(getByText('Found Disc')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('Found Disc')).toBeTruthy();
+    });
   });
 
-  it('navigates to found-disc when pressed', () => {
+  it('navigates to found-disc when pressed', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Found Disc')).toBeTruthy();
+    });
 
     fireEvent.press(getByText('Found Disc'));
 
     expect(mockPush).toHaveBeenCalledWith('/(tabs)/found-disc');
   });
 
-  it('shows Link Sticker quick action', () => {
+  it('shows Link Sticker quick action', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
 
-    expect(getByText('Link Sticker')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('Link Sticker')).toBeTruthy();
+    });
   });
 
-  it('navigates to link-sticker when pressed', () => {
+  it('navigates to link-sticker when pressed', async () => {
     useAuth.mockReturnValue({ user: mockUser });
     const { getByText } = render(<HomeScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Link Sticker')).toBeTruthy();
+    });
 
     fireEvent.press(getByText('Link Sticker'));
 
     expect(mockPush).toHaveBeenCalledWith('/link-sticker');
+  });
+
+  describe('with disc data', () => {
+    const mockDiscs = [
+      {
+        id: '1',
+        manufacturer: 'Innova',
+        plastic: 'Star',
+        color: 'Blue',
+        category: 'Distance Driver',
+        flight_numbers: { speed: 12, glide: 5, turn: -1, fade: 3 },
+      },
+      {
+        id: '2',
+        manufacturer: 'Innova',
+        plastic: 'Champion',
+        color: 'Red',
+        category: 'Fairway Driver',
+        flight_numbers: { speed: 7, glide: 5, turn: 0, fade: 2 },
+      },
+    ];
+
+    it('displays bag stats when discs are cached', async () => {
+      useAuth.mockReturnValue({ user: mockUser });
+      getCachedDiscs.mockResolvedValue(mockDiscs);
+
+      const { getByText } = render(<HomeScreen />);
+
+      await waitFor(() => {
+        expect(getByText('2')).toBeTruthy(); // Total discs
+      });
+      expect(getByText('Innova')).toBeTruthy(); // Top brand
+    });
+
+    it('shows empty state when no discs', async () => {
+      useAuth.mockReturnValue({ user: mockUser });
+      getCachedDiscs.mockResolvedValue([]);
+
+      const { getByText } = render(<HomeScreen />);
+
+      await waitFor(() => {
+        expect(getByText('No Bag Insights Yet')).toBeTruthy();
+      });
+    });
   });
 });

--- a/__tests__/utils/bagStats.test.ts
+++ b/__tests__/utils/bagStats.test.ts
@@ -1,0 +1,241 @@
+import {
+  calculateBagStats,
+  BagStats,
+  BagStatsDisc,
+} from '../../utils/bagStats';
+
+describe('calculateBagStats', () => {
+  describe('with empty disc array', () => {
+    it('returns sensible defaults', () => {
+      const result = calculateBagStats([]);
+
+      expect(result.totalDiscs).toBe(0);
+      expect(result.speedRange).toBeNull();
+      expect(result.topBrand).toBeNull();
+      expect(result.categoriesCount).toBe(0);
+      expect(result.totalCategories).toBe(7);
+      expect(result.stability.understable).toBe(0);
+      expect(result.stability.stable).toBe(0);
+      expect(result.stability.overstable).toBe(0);
+      expect(result.topPlastics).toEqual([]);
+      expect(result.colorDistribution).toEqual([]);
+    });
+  });
+
+  describe('with a single disc', () => {
+    it('calculates stats correctly', () => {
+      const discs: BagStatsDisc[] = [
+        {
+          id: '1',
+          manufacturer: 'Innova',
+          plastic: 'Star',
+          color: 'Blue',
+          category: 'Distance Driver',
+          flight_numbers: { speed: 12, glide: 5, turn: -1, fade: 3 },
+        },
+      ];
+
+      const result = calculateBagStats(discs);
+
+      expect(result.totalDiscs).toBe(1);
+      expect(result.speedRange).toEqual({ min: 12, max: 12 });
+      expect(result.topBrand).toEqual({ name: 'Innova', count: 1 });
+      expect(result.categoriesCount).toBe(1);
+      expect(result.stability.stable).toBe(1); // turn -1 is stable
+      expect(result.topPlastics).toEqual([{ name: 'Star', count: 1 }]);
+      expect(result.colorDistribution).toEqual([{ color: 'Blue', count: 1 }]);
+    });
+  });
+
+  describe('with multiple discs', () => {
+    const discs: BagStatsDisc[] = [
+      {
+        id: '1',
+        manufacturer: 'Innova',
+        plastic: 'Star',
+        color: 'Blue',
+        category: 'Distance Driver',
+        flight_numbers: { speed: 12, glide: 5, turn: -3, fade: 2 },
+      },
+      {
+        id: '2',
+        manufacturer: 'Innova',
+        plastic: 'Champion',
+        color: 'Red',
+        category: 'Fairway Driver',
+        flight_numbers: { speed: 7, glide: 5, turn: 0, fade: 2 },
+      },
+      {
+        id: '3',
+        manufacturer: 'Discraft',
+        plastic: 'ESP',
+        color: 'Blue',
+        category: 'Midrange',
+        flight_numbers: { speed: 5, glide: 4, turn: -1, fade: 1 },
+      },
+      {
+        id: '4',
+        manufacturer: 'Innova',
+        plastic: 'Star',
+        color: 'Yellow',
+        category: 'Putter',
+        flight_numbers: { speed: 3, glide: 3, turn: 0, fade: 2 },
+      },
+      {
+        id: '5',
+        manufacturer: 'MVP',
+        plastic: 'Neutron',
+        color: 'Green',
+        category: 'Distance Driver',
+        flight_numbers: { speed: 13, glide: 5, turn: 1, fade: 3 },
+      },
+    ];
+
+    it('calculates total discs', () => {
+      const result = calculateBagStats(discs);
+      expect(result.totalDiscs).toBe(5);
+    });
+
+    it('calculates speed range', () => {
+      const result = calculateBagStats(discs);
+      expect(result.speedRange).toEqual({ min: 3, max: 13 });
+    });
+
+    it('finds top brand by count', () => {
+      const result = calculateBagStats(discs);
+      expect(result.topBrand).toEqual({ name: 'Innova', count: 3 });
+    });
+
+    it('counts unique categories', () => {
+      const result = calculateBagStats(discs);
+      expect(result.categoriesCount).toBe(4); // Distance, Fairway, Midrange, Putter
+    });
+
+    it('calculates stability breakdown', () => {
+      const result = calculateBagStats(discs);
+      // turn <= -2: understable (1 disc with turn -3)
+      // turn > -2 AND turn <= 0: stable (3 discs with turn -1, 0, 0)
+      // turn > 0: overstable (1 disc with turn 1)
+      expect(result.stability.understable).toBe(1);
+      expect(result.stability.stable).toBe(3);
+      expect(result.stability.overstable).toBe(1);
+    });
+
+    it('lists top plastics sorted by count', () => {
+      const result = calculateBagStats(discs);
+      expect(result.topPlastics[0]).toEqual({ name: 'Star', count: 2 });
+      expect(result.topPlastics.length).toBeLessThanOrEqual(3);
+    });
+
+    it('calculates color distribution sorted by count', () => {
+      const result = calculateBagStats(discs);
+      expect(result.colorDistribution[0]).toEqual({ color: 'Blue', count: 2 });
+      expect(result.colorDistribution.length).toBe(4); // Blue, Red, Yellow, Green
+    });
+  });
+
+  describe('with missing data', () => {
+    it('handles missing flight numbers', () => {
+      const discs: BagStatsDisc[] = [
+        {
+          id: '1',
+          manufacturer: 'Innova',
+          // no flight_numbers
+        },
+        {
+          id: '2',
+          manufacturer: 'Discraft',
+          flight_numbers: { speed: 10, glide: 4, turn: null, fade: 2 },
+        },
+      ];
+
+      const result = calculateBagStats(discs);
+
+      expect(result.totalDiscs).toBe(2);
+      expect(result.speedRange).toEqual({ min: 10, max: 10 });
+      expect(result.stability.understable).toBe(0);
+      expect(result.stability.stable).toBe(0);
+      expect(result.stability.overstable).toBe(0);
+    });
+
+    it('handles missing manufacturer', () => {
+      const discs: BagStatsDisc[] = [
+        { id: '1' },
+        { id: '2', manufacturer: 'Innova' },
+      ];
+
+      const result = calculateBagStats(discs);
+
+      expect(result.topBrand).toEqual({ name: 'Innova', count: 1 });
+    });
+
+    it('handles missing plastic', () => {
+      const discs: BagStatsDisc[] = [
+        { id: '1' },
+        { id: '2', plastic: 'Star' },
+      ];
+
+      const result = calculateBagStats(discs);
+
+      expect(result.topPlastics).toEqual([{ name: 'Star', count: 1 }]);
+    });
+
+    it('handles missing color', () => {
+      const discs: BagStatsDisc[] = [
+        { id: '1' },
+        { id: '2', color: 'Blue' },
+      ];
+
+      const result = calculateBagStats(discs);
+
+      expect(result.colorDistribution).toEqual([{ color: 'Blue', count: 1 }]);
+    });
+
+    it('handles missing category', () => {
+      const discs: BagStatsDisc[] = [
+        { id: '1' },
+        { id: '2', category: 'Putter' },
+      ];
+
+      const result = calculateBagStats(discs);
+
+      expect(result.categoriesCount).toBe(1);
+    });
+  });
+
+  describe('stability classification', () => {
+    it('classifies turn <= -2 as understable', () => {
+      const discs: BagStatsDisc[] = [
+        { id: '1', flight_numbers: { speed: 12, glide: 5, turn: -2, fade: 2 } },
+        { id: '2', flight_numbers: { speed: 12, glide: 5, turn: -3, fade: 1 } },
+        { id: '3', flight_numbers: { speed: 12, glide: 5, turn: -5, fade: 1 } },
+      ];
+
+      const result = calculateBagStats(discs);
+
+      expect(result.stability.understable).toBe(3);
+    });
+
+    it('classifies turn > -2 AND turn <= 0 as stable', () => {
+      const discs: BagStatsDisc[] = [
+        { id: '1', flight_numbers: { speed: 12, glide: 5, turn: -1, fade: 2 } },
+        { id: '2', flight_numbers: { speed: 5, glide: 4, turn: 0, fade: 1 } },
+      ];
+
+      const result = calculateBagStats(discs);
+
+      expect(result.stability.stable).toBe(2);
+    });
+
+    it('classifies turn > 0 as overstable', () => {
+      const discs: BagStatsDisc[] = [
+        { id: '1', flight_numbers: { speed: 12, glide: 5, turn: 1, fade: 3 } },
+        { id: '2', flight_numbers: { speed: 5, glide: 4, turn: 2, fade: 4 } },
+      ];
+
+      const result = calculateBagStats(discs);
+
+      expect(result.stability.overstable).toBe(2);
+    });
+  });
+});

--- a/components/BagDashboard.tsx
+++ b/components/BagDashboard.tsx
@@ -1,0 +1,352 @@
+import { StyleSheet, View as RNView, useColorScheme, Pressable } from 'react-native';
+import { Text } from '@/components/Themed';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import Colors from '@/constants/Colors';
+import { DISC_COLORS } from '@/constants/discColors';
+import StatCard from './StatCard';
+import StabilityChart from './StabilityChart';
+import RecoveryAlert from './RecoveryAlert';
+import { BagStats } from '@/utils/bagStats';
+import { Skeleton } from './Skeleton';
+
+interface BagDashboardProps {
+  stats: BagStats | null;
+  activeRecoveryCount: number;
+  loading: boolean;
+  onRecoveryPress: () => void;
+  onAnalyzePress: () => void;
+}
+
+export default function BagDashboard({
+  stats,
+  activeRecoveryCount,
+  loading,
+  onRecoveryPress,
+  onAnalyzePress,
+}: BagDashboardProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  if (loading) {
+    return <DashboardSkeleton isDark={isDark} />;
+  }
+
+  if (!stats || stats.totalDiscs === 0) {
+    return <EmptyState isDark={isDark} />;
+  }
+
+  const dynamicStyles = {
+    section: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : '#e0e0e0',
+    },
+    sectionTitle: {
+      color: isDark ? '#fff' : '#000',
+    },
+    secondaryText: {
+      color: isDark ? '#999' : '#666',
+    },
+    analyzeButton: {
+      backgroundColor: isDark ? 'rgba(139, 92, 246, 0.2)' : Colors.violet[50],
+      borderColor: isDark ? 'rgba(139, 92, 246, 0.3)' : Colors.violet[100],
+    },
+  };
+
+  return (
+    <RNView style={styles.container}>
+      {/* Recovery Alert */}
+      <RecoveryAlert count={activeRecoveryCount} onPress={onRecoveryPress} />
+
+      {/* Quick Stats Grid */}
+      <RNView style={styles.statsGrid}>
+        <StatCard
+          icon="circle-o"
+          value={stats.totalDiscs}
+          label="Total Discs"
+        />
+        <StatCard
+          icon="tachometer"
+          value={stats.speedRange ? `${stats.speedRange.min}-${stats.speedRange.max}` : '--'}
+          label="Speed Range"
+        />
+      </RNView>
+      <RNView style={styles.statsGrid}>
+        <StatCard
+          icon="star"
+          value={stats.topBrand?.name || '--'}
+          label={stats.topBrand ? `${stats.topBrand.count} discs` : 'Top Brand'}
+        />
+        <StatCard
+          icon="th-large"
+          value={`${stats.categoriesCount}/${stats.totalCategories}`}
+          label="Categories"
+        />
+      </RNView>
+
+      {/* Stability Breakdown */}
+      <RNView style={styles.stabilitySection}>
+        <StabilityChart
+          understable={stats.stability.understable}
+          stable={stats.stability.stable}
+          overstable={stats.stability.overstable}
+        />
+      </RNView>
+
+      {/* Plastics & Colors Section */}
+      {(stats.topPlastics.length > 0 || stats.colorDistribution.length > 0) && (
+        <RNView style={[styles.preferencesSection, dynamicStyles.section]}>
+          <RNView style={styles.preferencesGrid}>
+            {/* Top Plastics */}
+            {stats.topPlastics.length > 0 && (
+              <RNView style={styles.preferenceColumn}>
+                <Text style={[styles.preferenceTitle, dynamicStyles.sectionTitle]}>
+                  Top Plastics
+                </Text>
+                {stats.topPlastics.slice(0, 3).map((plastic, index) => (
+                  <RNView key={plastic.name} style={styles.preferenceRow}>
+                    <Text style={[styles.preferenceRank, dynamicStyles.secondaryText]}>
+                      {index + 1}.
+                    </Text>
+                    <Text style={[styles.preferenceName, dynamicStyles.sectionTitle]} numberOfLines={1}>
+                      {plastic.name}
+                    </Text>
+                    <Text style={[styles.preferenceCount, dynamicStyles.secondaryText]}>
+                      {plastic.count}
+                    </Text>
+                  </RNView>
+                ))}
+              </RNView>
+            )}
+
+            {/* Color Distribution */}
+            {stats.colorDistribution.length > 0 && (
+              <RNView style={styles.preferenceColumn}>
+                <Text style={[styles.preferenceTitle, dynamicStyles.sectionTitle]}>
+                  Colors
+                </Text>
+                <RNView style={styles.colorGrid}>
+                  {stats.colorDistribution.slice(0, 6).map((colorItem) => (
+                    <RNView key={colorItem.color} style={styles.colorItem}>
+                      <ColorDot color={colorItem.color} />
+                      <Text style={[styles.colorCount, dynamicStyles.secondaryText]}>
+                        {colorItem.count}
+                      </Text>
+                    </RNView>
+                  ))}
+                </RNView>
+              </RNView>
+            )}
+          </RNView>
+        </RNView>
+      )}
+
+      {/* Full Analysis CTA */}
+      <Pressable style={[styles.analyzeButton, dynamicStyles.analyzeButton]} onPress={onAnalyzePress}>
+        <FontAwesome name="lightbulb-o" size={16} color={isDark ? '#fbbf24' : '#F39C12'} />
+        <Text style={styles.analyzeButtonText}>Get AI Recommendations</Text>
+        <FontAwesome name="chevron-right" size={12} color={isDark ? '#888' : '#999'} />
+      </Pressable>
+    </RNView>
+  );
+}
+
+function ColorDot({ color }: { color: string }) {
+  const hexColor = DISC_COLORS[color as keyof typeof DISC_COLORS] || '#666';
+
+  if (hexColor === 'rainbow') {
+    return (
+      <RNView style={styles.rainbowDot}>
+        <RNView style={[styles.rainbowSlice, { backgroundColor: '#E74C3C' }]} />
+        <RNView style={[styles.rainbowSlice, { backgroundColor: '#F1C40F' }]} />
+        <RNView style={[styles.rainbowSlice, { backgroundColor: '#2ECC71' }]} />
+        <RNView style={[styles.rainbowSlice, { backgroundColor: '#3498DB' }]} />
+      </RNView>
+    );
+  }
+
+  return (
+    <RNView
+      style={[
+        styles.colorDot,
+        {
+          backgroundColor: hexColor,
+          borderColor: color === 'White' ? '#ccc' : 'transparent',
+        },
+      ]}
+    />
+  );
+}
+
+function EmptyState({ isDark }: { isDark: boolean }) {
+  return (
+    <RNView style={[styles.emptyState, { backgroundColor: isDark ? '#1a1a1a' : '#f8f8f8' }]}>
+      <FontAwesome name="pie-chart" size={32} color={isDark ? '#666' : '#ccc'} />
+      <Text style={[styles.emptyTitle, { color: isDark ? '#fff' : '#000' }]}>
+        No Bag Insights Yet
+      </Text>
+      <Text style={[styles.emptySubtitle, { color: isDark ? '#999' : '#666' }]}>
+        Add discs to your bag to see stats and insights
+      </Text>
+    </RNView>
+  );
+}
+
+function DashboardSkeleton({ isDark }: { isDark: boolean }) {
+  return (
+    <RNView style={styles.container}>
+      {/* Stats Grid Skeleton */}
+      <RNView style={styles.statsGrid}>
+        <RNView style={[styles.skeletonCard, { backgroundColor: isDark ? '#1a1a1a' : '#f0f0f0' }]}>
+          <Skeleton width={32} height={32} borderRadius={16} />
+          <Skeleton width={40} height={20} style={{ marginTop: 8 }} />
+          <Skeleton width={60} height={12} style={{ marginTop: 4 }} />
+        </RNView>
+        <RNView style={[styles.skeletonCard, { backgroundColor: isDark ? '#1a1a1a' : '#f0f0f0' }]}>
+          <Skeleton width={32} height={32} borderRadius={16} />
+          <Skeleton width={40} height={20} style={{ marginTop: 8 }} />
+          <Skeleton width={60} height={12} style={{ marginTop: 4 }} />
+        </RNView>
+      </RNView>
+      <RNView style={styles.statsGrid}>
+        <RNView style={[styles.skeletonCard, { backgroundColor: isDark ? '#1a1a1a' : '#f0f0f0' }]}>
+          <Skeleton width={32} height={32} borderRadius={16} />
+          <Skeleton width={50} height={20} style={{ marginTop: 8 }} />
+          <Skeleton width={60} height={12} style={{ marginTop: 4 }} />
+        </RNView>
+        <RNView style={[styles.skeletonCard, { backgroundColor: isDark ? '#1a1a1a' : '#f0f0f0' }]}>
+          <Skeleton width={32} height={32} borderRadius={16} />
+          <Skeleton width={30} height={20} style={{ marginTop: 8 }} />
+          <Skeleton width={60} height={12} style={{ marginTop: 4 }} />
+        </RNView>
+      </RNView>
+
+      {/* Stability Chart Skeleton */}
+      <RNView style={[styles.skeletonStability, { backgroundColor: isDark ? '#1a1a1a' : '#f0f0f0' }]}>
+        <Skeleton width={120} height={16} style={{ marginBottom: 12 }} />
+        <Skeleton width="100%" height={8} style={{ marginBottom: 10 }} />
+        <Skeleton width="100%" height={8} style={{ marginBottom: 10 }} />
+        <Skeleton width="100%" height={8} />
+      </RNView>
+    </RNView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  statsGrid: {
+    flexDirection: 'row',
+    gap: 12,
+    marginBottom: 12,
+  },
+  stabilitySection: {
+    marginBottom: 12,
+  },
+  preferencesSection: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 12,
+  },
+  preferencesGrid: {
+    flexDirection: 'row',
+    gap: 16,
+  },
+  preferenceColumn: {
+    flex: 1,
+  },
+  preferenceTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  preferenceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  preferenceRank: {
+    fontSize: 12,
+    width: 16,
+  },
+  preferenceName: {
+    fontSize: 13,
+    flex: 1,
+  },
+  preferenceCount: {
+    fontSize: 12,
+    marginLeft: 8,
+  },
+  colorGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  colorItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  colorDot: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  rainbowDot: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    overflow: 'hidden',
+    flexDirection: 'row',
+  },
+  rainbowSlice: {
+    flex: 1,
+    height: '100%',
+  },
+  colorCount: {
+    fontSize: 12,
+  },
+  analyzeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    gap: 8,
+  },
+  analyzeButtonText: {
+    fontSize: 14,
+    fontWeight: '500',
+    flex: 1,
+  },
+  emptyState: {
+    alignItems: 'center',
+    padding: 24,
+    borderRadius: 12,
+    marginBottom: 16,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  emptySubtitle: {
+    fontSize: 13,
+    textAlign: 'center',
+  },
+  skeletonCard: {
+    flex: 1,
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 12,
+  },
+  skeletonStability: {
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 12,
+  },
+});

--- a/components/RecoveryAlert.tsx
+++ b/components/RecoveryAlert.tsx
@@ -1,0 +1,82 @@
+import { StyleSheet, Pressable, View as RNView, useColorScheme } from 'react-native';
+import { Text } from '@/components/Themed';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+
+interface RecoveryAlertProps {
+  count: number;
+  onPress: () => void;
+}
+
+export default function RecoveryAlert({ count, onPress }: RecoveryAlertProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  if (count === 0) {
+    return null;
+  }
+
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? 'rgba(243, 156, 18, 0.15)' : '#FFF8E7',
+      borderColor: isDark ? 'rgba(243, 156, 18, 0.3)' : '#FFE4B5',
+    },
+    iconBg: {
+      backgroundColor: isDark ? 'rgba(243, 156, 18, 0.2)' : '#fff',
+    },
+    title: {
+      color: isDark ? '#fbbf24' : '#D68910',
+    },
+    subtitle: {
+      color: isDark ? '#ccc' : '#666',
+    },
+  };
+
+  const discWord = count === 1 ? 'disc' : 'discs';
+
+  return (
+    <Pressable style={[styles.container, dynamicStyles.container]} onPress={onPress}>
+      <RNView style={[styles.iconContainer, dynamicStyles.iconBg]}>
+        <FontAwesome name="bell" size={18} color={isDark ? '#fbbf24' : '#F39C12'} />
+      </RNView>
+      <RNView style={styles.textContainer}>
+        <Text style={[styles.title, dynamicStyles.title]}>
+          {count} {discWord} being recovered
+        </Text>
+        <Text style={[styles.subtitle, dynamicStyles.subtitle]}>
+          Tap to view recovery status
+        </Text>
+      </RNView>
+      <FontAwesome name="chevron-right" size={14} color={isDark ? '#888' : '#999'} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 16,
+  },
+  iconContainer: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  },
+  textContainer: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 2,
+  },
+  subtitle: {
+    fontSize: 12,
+  },
+});

--- a/components/StabilityChart.tsx
+++ b/components/StabilityChart.tsx
@@ -1,0 +1,191 @@
+import { StyleSheet, View as RNView, useColorScheme } from 'react-native';
+import { Text } from '@/components/Themed';
+
+interface StabilityChartProps {
+  understable: number;
+  stable: number;
+  overstable: number;
+}
+
+const COLORS = {
+  understable: '#27AE60', // Green
+  stable: '#3498DB', // Blue
+  overstable: '#E74C3C', // Red
+};
+
+export default function StabilityChart({
+  understable,
+  stable,
+  overstable,
+}: StabilityChartProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const total = understable + stable + overstable;
+
+  if (total === 0) {
+    return (
+      <RNView style={[styles.container, { backgroundColor: isDark ? '#1a1a1a' : '#f8f8f8' }]}>
+        <Text style={[styles.title, { color: isDark ? '#fff' : '#000' }]}>
+          Stability Breakdown
+        </Text>
+        <Text style={styles.emptyText}>Add discs with flight numbers to see stability breakdown</Text>
+      </RNView>
+    );
+  }
+
+  const getPercentage = (count: number) => Math.round((count / total) * 100);
+
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : '#e0e0e0',
+    },
+    barBackground: {
+      backgroundColor: isDark ? '#333' : '#e0e0e0',
+    },
+    title: {
+      color: isDark ? '#fff' : '#000',
+    },
+    label: {
+      color: isDark ? '#ccc' : '#333',
+    },
+    count: {
+      color: isDark ? '#999' : '#666',
+    },
+  };
+
+  return (
+    <RNView style={[styles.container, dynamicStyles.container]}>
+      <Text style={[styles.title, dynamicStyles.title]}>Stability Breakdown</Text>
+
+      {/* Understable */}
+      <RNView style={styles.row}>
+        <RNView style={styles.labelContainer}>
+          <RNView style={[styles.dot, { backgroundColor: COLORS.understable }]} />
+          <Text style={[styles.label, dynamicStyles.label]}>Understable</Text>
+        </RNView>
+        <RNView style={styles.barContainer}>
+          <RNView style={[styles.barBackground, dynamicStyles.barBackground]}>
+            <RNView
+              style={[
+                styles.barFill,
+                {
+                  backgroundColor: COLORS.understable,
+                  width: `${getPercentage(understable)}%`,
+                },
+              ]}
+            />
+          </RNView>
+        </RNView>
+        <Text style={[styles.count, dynamicStyles.count]}>
+          {understable} ({getPercentage(understable)}%)
+        </Text>
+      </RNView>
+
+      {/* Stable */}
+      <RNView style={styles.row}>
+        <RNView style={styles.labelContainer}>
+          <RNView style={[styles.dot, { backgroundColor: COLORS.stable }]} />
+          <Text style={[styles.label, dynamicStyles.label]}>Stable</Text>
+        </RNView>
+        <RNView style={styles.barContainer}>
+          <RNView style={[styles.barBackground, dynamicStyles.barBackground]}>
+            <RNView
+              style={[
+                styles.barFill,
+                {
+                  backgroundColor: COLORS.stable,
+                  width: `${getPercentage(stable)}%`,
+                },
+              ]}
+            />
+          </RNView>
+        </RNView>
+        <Text style={[styles.count, dynamicStyles.count]}>
+          {stable} ({getPercentage(stable)}%)
+        </Text>
+      </RNView>
+
+      {/* Overstable */}
+      <RNView style={styles.row}>
+        <RNView style={styles.labelContainer}>
+          <RNView style={[styles.dot, { backgroundColor: COLORS.overstable }]} />
+          <Text style={[styles.label, dynamicStyles.label]}>Overstable</Text>
+        </RNView>
+        <RNView style={styles.barContainer}>
+          <RNView style={[styles.barBackground, dynamicStyles.barBackground]}>
+            <RNView
+              style={[
+                styles.barFill,
+                {
+                  backgroundColor: COLORS.overstable,
+                  width: `${getPercentage(overstable)}%`,
+                },
+              ]}
+            />
+          </RNView>
+        </RNView>
+        <Text style={[styles.count, dynamicStyles.count]}>
+          {overstable} ({getPercentage(overstable)}%)
+        </Text>
+      </RNView>
+    </RNView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  labelContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: 90,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginRight: 6,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  barContainer: {
+    flex: 1,
+    marginHorizontal: 8,
+  },
+  barBackground: {
+    height: 8,
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  barFill: {
+    height: '100%',
+    borderRadius: 4,
+  },
+  count: {
+    fontSize: 11,
+    width: 60,
+    textAlign: 'right',
+  },
+  emptyText: {
+    fontSize: 13,
+    color: '#999',
+    textAlign: 'center',
+  },
+});

--- a/components/StatCard.tsx
+++ b/components/StatCard.tsx
@@ -1,0 +1,66 @@
+import { StyleSheet, View as RNView, useColorScheme } from 'react-native';
+import { Text } from '@/components/Themed';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import Colors from '@/constants/Colors';
+
+interface StatCardProps {
+  icon: React.ComponentProps<typeof FontAwesome>['name'];
+  value: string | number;
+  label: string;
+  iconColor?: string;
+}
+
+export default function StatCard({ icon, value, label, iconColor }: StatCardProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const dynamicStyles = {
+    card: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : '#e0e0e0',
+    },
+    iconBg: {
+      backgroundColor: isDark ? 'rgba(139, 92, 246, 0.2)' : Colors.violet[50],
+    },
+  };
+
+  const finalIconColor = iconColor || (isDark ? '#a78bfa' : Colors.violet.primary);
+
+  return (
+    <RNView style={[styles.card, dynamicStyles.card]}>
+      <RNView style={[styles.iconContainer, dynamicStyles.iconBg]}>
+        <FontAwesome name={icon} size={16} color={finalIconColor} />
+      </RNView>
+      <Text style={styles.value}>{value}</Text>
+      <Text style={styles.label}>{label}</Text>
+    </RNView>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  iconContainer: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 8,
+  },
+  value: {
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 2,
+  },
+  label: {
+    fontSize: 11,
+    color: '#666',
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- Add comprehensive stats dashboard to the home page showing bag insights
- Display total discs, speed range, top brand, and categories covered
- Show stability breakdown chart (understable/stable/overstable)
- Display top plastics and color distribution
- Show recovery alerts when discs are being recovered
- Add CTA to get AI recommendations

## New Components
- `BagDashboard`: Main dashboard component
- `StatCard`: Reusable stat display card
- `StabilityChart`: Visual bar chart for stability
- `RecoveryAlert`: Banner for active recoveries
- `bagStats.ts`: Utility for calculating stats client-side

## Test plan
- [ ] Verify dashboard appears on home page
- [ ] Test with cached disc data shows correct stats
- [ ] Verify empty state when no discs
- [ ] Confirm dark mode styling works correctly
- [ ] Test recovery alert appears when recoveries exist
- [ ] Tap "Get AI Recommendations" navigates to disc-recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)