### PR TITLE
feat: add category, speed, and stability-by-category charts to dashboard

### DIFF
--- a/__tests__/utils/bagStats.test.ts
+++ b/__tests__/utils/bagStats.test.ts
@@ -17,6 +17,9 @@ describe('calculateBagStats', () => {
       expect(result.stability.understable).toBe(0);
       expect(result.stability.stable).toBe(0);
       expect(result.stability.overstable).toBe(0);
+      expect(result.stabilityByCategory).toEqual([]);
+      expect(result.categoryDistribution).toEqual([]);
+      expect(result.speedDistribution).toEqual([]);
       expect(result.topPlastics).toEqual([]);
       expect(result.colorDistribution).toEqual([]);
     });
@@ -42,6 +45,11 @@ describe('calculateBagStats', () => {
       expect(result.topBrand).toEqual({ name: 'Innova', count: 1 });
       expect(result.categoriesCount).toBe(1);
       expect(result.stability.stable).toBe(1); // turn -1 is stable
+      expect(result.categoryDistribution).toEqual([{ category: 'Distance Driver', count: 1 }]);
+      expect(result.speedDistribution).toEqual([{ speed: 12, count: 1 }]);
+      expect(result.stabilityByCategory).toEqual([
+        { category: 'Distance Driver', understable: 0, stable: 1, overstable: 0 },
+      ]);
       expect(result.topPlastics).toEqual([{ name: 'Star', count: 1 }]);
       expect(result.colorDistribution).toEqual([{ color: 'Blue', count: 1 }]);
     });
@@ -131,6 +139,41 @@ describe('calculateBagStats', () => {
       const result = calculateBagStats(discs);
       expect(result.colorDistribution[0]).toEqual({ color: 'Blue', count: 2 });
       expect(result.colorDistribution.length).toBe(4); // Blue, Red, Yellow, Green
+    });
+
+    it('calculates category distribution sorted by count', () => {
+      const result = calculateBagStats(discs);
+      expect(result.categoryDistribution[0]).toEqual({ category: 'Distance Driver', count: 2 });
+      expect(result.categoryDistribution.length).toBe(4);
+    });
+
+    it('calculates speed distribution sorted by speed', () => {
+      const result = calculateBagStats(discs);
+      // Speeds: 3, 5, 7, 12, 13
+      expect(result.speedDistribution).toEqual([
+        { speed: 3, count: 1 },
+        { speed: 5, count: 1 },
+        { speed: 7, count: 1 },
+        { speed: 12, count: 1 },
+        { speed: 13, count: 1 },
+      ]);
+    });
+
+    it('calculates stability by category', () => {
+      const result = calculateBagStats(discs);
+      // Distance Driver: 1 understable (-3), 1 overstable (1)
+      // Fairway: 1 stable (0)
+      // Midrange: 1 stable (-1)
+      // Putter: 1 stable (0)
+      const distanceDriver = result.stabilityByCategory.find(
+        (c) => c.category === 'Distance Driver'
+      );
+      expect(distanceDriver).toEqual({
+        category: 'Distance Driver',
+        understable: 1,
+        stable: 0,
+        overstable: 1,
+      });
     });
   });
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -130,15 +130,6 @@ export default function HomeScreen() {
         </Text>
       </RNView>
 
-      {/* Bag Dashboard */}
-      <BagDashboard
-        stats={bagStats}
-        activeRecoveryCount={activeRecoveryCount}
-        loading={loadingDiscs}
-        onRecoveryPress={handleRecoveryPress}
-        onAnalyzePress={handleAnalyzePress}
-      />
-
       {/* Order Stickers CTA Card */}
       <Pressable style={[styles.stickerCard, dynamicStyles.stickerCard]} onPress={() => router.push('/order-stickers')}>
         <RNView style={styles.stickerCardContent}>
@@ -199,6 +190,15 @@ export default function HomeScreen() {
           <Text style={styles.quickActionText}>Fill My Bag</Text>
         </Pressable>
       </RNView>
+
+      {/* Bag Dashboard - Stats and Charts */}
+      <BagDashboard
+        stats={bagStats}
+        activeRecoveryCount={activeRecoveryCount}
+        loading={loadingDiscs}
+        onRecoveryPress={handleRecoveryPress}
+        onAnalyzePress={handleAnalyzePress}
+      />
     </ScrollView>
   );
 }

--- a/components/BagDashboard.tsx
+++ b/components/BagDashboard.tsx
@@ -5,6 +5,9 @@ import Colors from '@/constants/Colors';
 import { DISC_COLORS } from '@/constants/discColors';
 import StatCard from './StatCard';
 import StabilityChart from './StabilityChart';
+import CategoryChart from './CategoryChart';
+import SpeedChart from './SpeedChart';
+import StabilityByCategoryChart from './StabilityByCategoryChart';
 import RecoveryAlert from './RecoveryAlert';
 import { BagStats } from '@/utils/bagStats';
 import { Skeleton } from './Skeleton';
@@ -57,6 +60,11 @@ export default function BagDashboard({
       {/* Recovery Alert */}
       <RecoveryAlert count={activeRecoveryCount} onPress={onRecoveryPress} />
 
+      {/* Section Title */}
+      <Text style={[styles.sectionHeader, dynamicStyles.sectionTitle]}>
+        Bag Insights
+      </Text>
+
       {/* Quick Stats Grid */}
       <RNView style={styles.statsGrid}>
         <StatCard
@@ -70,27 +78,54 @@ export default function BagDashboard({
           label="Speed Range"
         />
       </RNView>
-      <RNView style={styles.statsGrid}>
-        <StatCard
-          icon="star"
-          value={stats.topBrand?.name || '--'}
-          label={stats.topBrand ? `${stats.topBrand.count} discs` : 'Top Brand'}
-        />
-        <StatCard
-          icon="th-large"
-          value={`${stats.categoriesCount}/${stats.totalCategories}`}
-          label="Categories"
-        />
+
+      {/* Top Brand - with "Most Popular" label */}
+      {stats.topBrand && (
+        <RNView style={[styles.topBrandCard, dynamicStyles.section]}>
+          <RNView style={styles.topBrandHeader}>
+            <FontAwesome
+              name="trophy"
+              size={16}
+              color={isDark ? '#fbbf24' : '#F39C12'}
+            />
+            <Text style={[styles.topBrandLabel, dynamicStyles.secondaryText]}>
+              Most Popular Brand
+            </Text>
+          </RNView>
+          <Text style={[styles.topBrandName, dynamicStyles.sectionTitle]}>
+            {stats.topBrand.name}
+          </Text>
+          <Text style={[styles.topBrandCount, dynamicStyles.secondaryText]}>
+            {stats.topBrand.count} disc{stats.topBrand.count !== 1 ? 's' : ''}
+          </Text>
+        </RNView>
+      )}
+
+      {/* Disc Types Chart */}
+      <RNView style={styles.chartSection}>
+        <CategoryChart distribution={stats.categoryDistribution} />
       </RNView>
 
-      {/* Stability Breakdown */}
-      <RNView style={styles.stabilitySection}>
+      {/* Speed Distribution Chart */}
+      <RNView style={styles.chartSection}>
+        <SpeedChart distribution={stats.speedDistribution} />
+      </RNView>
+
+      {/* Overall Stability Breakdown */}
+      <RNView style={styles.chartSection}>
         <StabilityChart
           understable={stats.stability.understable}
           stable={stats.stability.stable}
           overstable={stats.stability.overstable}
         />
       </RNView>
+
+      {/* Stability by Category */}
+      {stats.stabilityByCategory.length > 0 && (
+        <RNView style={styles.chartSection}>
+          <StabilityByCategoryChart data={stats.stabilityByCategory} />
+        </RNView>
+      )}
 
       {/* Plastics & Colors Section */}
       {(stats.topPlastics.length > 0 || stats.colorDistribution.length > 0) && (
@@ -207,20 +242,8 @@ function DashboardSkeleton({ isDark }: { isDark: boolean }) {
           <Skeleton width={60} height={12} style={{ marginTop: 4 }} />
         </RNView>
       </RNView>
-      <RNView style={styles.statsGrid}>
-        <RNView style={[styles.skeletonCard, { backgroundColor: isDark ? '#1a1a1a' : '#f0f0f0' }]}>
-          <Skeleton width={32} height={32} borderRadius={16} />
-          <Skeleton width={50} height={20} style={{ marginTop: 8 }} />
-          <Skeleton width={60} height={12} style={{ marginTop: 4 }} />
-        </RNView>
-        <RNView style={[styles.skeletonCard, { backgroundColor: isDark ? '#1a1a1a' : '#f0f0f0' }]}>
-          <Skeleton width={32} height={32} borderRadius={16} />
-          <Skeleton width={30} height={20} style={{ marginTop: 8 }} />
-          <Skeleton width={60} height={12} style={{ marginTop: 4 }} />
-        </RNView>
-      </RNView>
 
-      {/* Stability Chart Skeleton */}
+      {/* Chart Skeleton */}
       <RNView style={[styles.skeletonStability, { backgroundColor: isDark ? '#1a1a1a' : '#f0f0f0' }]}>
         <Skeleton width={120} height={16} style={{ marginBottom: 12 }} />
         <Skeleton width="100%" height={8} style={{ marginBottom: 10 }} />
@@ -233,6 +256,12 @@ function DashboardSkeleton({ isDark }: { isDark: boolean }) {
 
 const styles = StyleSheet.create({
   container: {
+    marginTop: 24,
+    marginBottom: 16,
+  },
+  sectionHeader: {
+    fontSize: 18,
+    fontWeight: '700',
     marginBottom: 16,
   },
   statsGrid: {
@@ -240,7 +269,32 @@ const styles = StyleSheet.create({
     gap: 12,
     marginBottom: 12,
   },
-  stabilitySection: {
+  topBrandCard: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 12,
+    alignItems: 'center',
+  },
+  topBrandHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 8,
+  },
+  topBrandLabel: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  topBrandName: {
+    fontSize: 24,
+    fontWeight: '700',
+  },
+  topBrandCount: {
+    fontSize: 14,
+    marginTop: 4,
+  },
+  chartSection: {
     marginBottom: 12,
   },
   preferencesSection: {
@@ -326,6 +380,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 24,
     borderRadius: 12,
+    marginTop: 24,
     marginBottom: 16,
   },
   emptyTitle: {

--- a/components/CategoryChart.tsx
+++ b/components/CategoryChart.tsx
@@ -1,0 +1,172 @@
+import { StyleSheet, View as RNView, useColorScheme } from 'react-native';
+import { Text } from '@/components/Themed';
+
+interface CategoryChartProps {
+  distribution: Array<{ category: string; count: number }>;
+}
+
+// Colors for different disc categories
+const CATEGORY_COLORS: Record<string, string> = {
+  'Distance Driver': '#E74C3C', // Red
+  'Control Driver': '#E67E22', // Orange
+  'Hybrid Driver': '#F1C40F', // Yellow
+  'Fairway Driver': '#2ECC71', // Green
+  Midrange: '#3498DB', // Blue
+  Approach: '#9B59B6', // Purple
+  Putter: '#1ABC9C', // Teal
+};
+
+export default function CategoryChart({ distribution }: CategoryChartProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const total = distribution.reduce((sum, item) => sum + item.count, 0);
+
+  if (total === 0) {
+    return (
+      <RNView
+        style={[
+          styles.container,
+          { backgroundColor: isDark ? '#1a1a1a' : '#f8f8f8' },
+        ]}
+      >
+        <Text style={[styles.title, { color: isDark ? '#fff' : '#000' }]}>
+          Disc Types
+        </Text>
+        <Text style={styles.emptyText}>
+          Add discs to see your type distribution
+        </Text>
+      </RNView>
+    );
+  }
+
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : '#e0e0e0',
+    },
+    title: {
+      color: isDark ? '#fff' : '#000',
+    },
+    label: {
+      color: isDark ? '#ccc' : '#333',
+    },
+    count: {
+      color: isDark ? '#999' : '#666',
+    },
+    barBackground: {
+      backgroundColor: isDark ? '#333' : '#e0e0e0',
+    },
+  };
+
+  const getPercentage = (count: number) => Math.round((count / total) * 100);
+
+  return (
+    <RNView style={[styles.container, dynamicStyles.container]}>
+      <Text style={[styles.title, dynamicStyles.title]}>Disc Types</Text>
+
+      {distribution.map((item) => {
+        const color = CATEGORY_COLORS[item.category] || '#666';
+        const percentage = getPercentage(item.count);
+
+        return (
+          <RNView key={item.category} style={styles.row}>
+            <RNView style={styles.labelContainer}>
+              <RNView style={[styles.dot, { backgroundColor: color }]} />
+              <Text
+                style={[styles.label, dynamicStyles.label]}
+                numberOfLines={1}
+              >
+                {shortenCategory(item.category)}
+              </Text>
+            </RNView>
+            <RNView style={styles.barContainer}>
+              <RNView style={[styles.barBackground, dynamicStyles.barBackground]}>
+                <RNView
+                  style={[
+                    styles.barFill,
+                    {
+                      backgroundColor: color,
+                      width: `${percentage}%`,
+                    },
+                  ]}
+                />
+              </RNView>
+            </RNView>
+            <Text style={[styles.count, dynamicStyles.count]}>
+              {item.count} ({percentage}%)
+            </Text>
+          </RNView>
+        );
+      })}
+    </RNView>
+  );
+}
+
+// Shorten long category names for display
+function shortenCategory(category: string): string {
+  const map: Record<string, string> = {
+    'Distance Driver': 'Distance',
+    'Control Driver': 'Control',
+    'Hybrid Driver': 'Hybrid',
+    'Fairway Driver': 'Fairway',
+  };
+  return map[category] || category;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  labelContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: 80,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginRight: 6,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '500',
+    flex: 1,
+  },
+  barContainer: {
+    flex: 1,
+    marginHorizontal: 8,
+  },
+  barBackground: {
+    height: 8,
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  barFill: {
+    height: '100%',
+    borderRadius: 4,
+  },
+  count: {
+    fontSize: 11,
+    width: 60,
+    textAlign: 'right',
+  },
+  emptyText: {
+    fontSize: 13,
+    color: '#999',
+    textAlign: 'center',
+  },
+});

--- a/components/SpeedChart.tsx
+++ b/components/SpeedChart.tsx
@@ -1,0 +1,191 @@
+import { StyleSheet, View as RNView, useColorScheme } from 'react-native';
+import { Text } from '@/components/Themed';
+import Colors from '@/constants/Colors';
+
+interface SpeedChartProps {
+  distribution: Array<{ speed: number; count: number }>;
+}
+
+export default function SpeedChart({ distribution }: SpeedChartProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const total = distribution.reduce((sum, item) => sum + item.count, 0);
+  const maxCount = Math.max(...distribution.map((d) => d.count), 1);
+
+  if (total === 0) {
+    return (
+      <RNView
+        style={[
+          styles.container,
+          { backgroundColor: isDark ? '#1a1a1a' : '#f8f8f8' },
+        ]}
+      >
+        <Text style={[styles.title, { color: isDark ? '#fff' : '#000' }]}>
+          Speed Distribution
+        </Text>
+        <Text style={styles.emptyText}>
+          Add discs with flight numbers to see speed distribution
+        </Text>
+      </RNView>
+    );
+  }
+
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : '#e0e0e0',
+    },
+    title: {
+      color: isDark ? '#fff' : '#000',
+    },
+    speedLabel: {
+      color: isDark ? '#999' : '#666',
+    },
+  };
+
+  // Get color based on speed (gradient from blue to red)
+  const getSpeedColor = (speed: number): string => {
+    // Speed 1-4: Putters/Approach (teal)
+    // Speed 5-6: Midrange (blue)
+    // Speed 7-9: Fairway (green)
+    // Speed 10-11: Control (orange)
+    // Speed 12-14: Distance (red)
+    if (speed <= 4) return '#1ABC9C';
+    if (speed <= 6) return '#3498DB';
+    if (speed <= 9) return '#2ECC71';
+    if (speed <= 11) return '#E67E22';
+    return '#E74C3C';
+  };
+
+  return (
+    <RNView style={[styles.container, dynamicStyles.container]}>
+      <Text style={[styles.title, dynamicStyles.title]}>Speed Distribution</Text>
+
+      <RNView style={styles.chartContainer}>
+        {distribution.map((item) => {
+          const barHeight = (item.count / maxCount) * 60; // Max height 60
+          const color = getSpeedColor(item.speed);
+
+          return (
+            <RNView key={item.speed} style={styles.barColumn}>
+              <Text style={styles.countLabel}>{item.count}</Text>
+              <RNView style={styles.barWrapper}>
+                <RNView
+                  style={[
+                    styles.bar,
+                    {
+                      height: Math.max(barHeight, 4),
+                      backgroundColor: color,
+                    },
+                  ]}
+                />
+              </RNView>
+              <Text style={[styles.speedLabel, dynamicStyles.speedLabel]}>
+                {item.speed}
+              </Text>
+            </RNView>
+          );
+        })}
+      </RNView>
+
+      {/* Legend */}
+      <RNView style={styles.legend}>
+        <LegendItem color="#1ABC9C" label="Putter" isDark={isDark} />
+        <LegendItem color="#3498DB" label="Mid" isDark={isDark} />
+        <LegendItem color="#2ECC71" label="Fairway" isDark={isDark} />
+        <LegendItem color="#E67E22" label="Control" isDark={isDark} />
+        <LegendItem color="#E74C3C" label="Distance" isDark={isDark} />
+      </RNView>
+    </RNView>
+  );
+}
+
+function LegendItem({
+  color,
+  label,
+  isDark,
+}: {
+  color: string;
+  label: string;
+  isDark: boolean;
+}) {
+  return (
+    <RNView style={styles.legendItem}>
+      <RNView style={[styles.legendDot, { backgroundColor: color }]} />
+      <Text style={[styles.legendText, { color: isDark ? '#999' : '#666' }]}>
+        {label}
+      </Text>
+    </RNView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  chartContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-around',
+    height: 100,
+    marginBottom: 8,
+  },
+  barColumn: {
+    alignItems: 'center',
+    flex: 1,
+    maxWidth: 30,
+  },
+  countLabel: {
+    fontSize: 10,
+    color: '#666',
+    marginBottom: 4,
+  },
+  barWrapper: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    width: '100%',
+    paddingHorizontal: 2,
+  },
+  bar: {
+    width: '100%',
+    borderRadius: 3,
+    minHeight: 4,
+  },
+  speedLabel: {
+    fontSize: 10,
+    marginTop: 4,
+  },
+  legend: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    flexWrap: 'wrap',
+    gap: 12,
+    marginTop: 8,
+  },
+  legendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  legendDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginRight: 4,
+  },
+  legendText: {
+    fontSize: 10,
+  },
+  emptyText: {
+    fontSize: 13,
+    color: '#999',
+    textAlign: 'center',
+  },
+});

--- a/components/StabilityByCategoryChart.tsx
+++ b/components/StabilityByCategoryChart.tsx
@@ -1,0 +1,241 @@
+import { StyleSheet, View as RNView, useColorScheme } from 'react-native';
+import { Text } from '@/components/Themed';
+
+interface StabilityByCategoryChartProps {
+  data: Array<{
+    category: string;
+    understable: number;
+    stable: number;
+    overstable: number;
+  }>;
+}
+
+const STABILITY_COLORS = {
+  understable: '#27AE60', // Green
+  stable: '#3498DB', // Blue
+  overstable: '#E74C3C', // Red
+};
+
+export default function StabilityByCategoryChart({
+  data,
+}: StabilityByCategoryChartProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  if (data.length === 0) {
+    return (
+      <RNView
+        style={[
+          styles.container,
+          { backgroundColor: isDark ? '#1a1a1a' : '#f8f8f8' },
+        ]}
+      >
+        <Text style={[styles.title, { color: isDark ? '#fff' : '#000' }]}>
+          Stability by Type
+        </Text>
+        <Text style={styles.emptyText}>
+          Add discs with categories and flight numbers
+        </Text>
+      </RNView>
+    );
+  }
+
+  const dynamicStyles = {
+    container: {
+      backgroundColor: isDark ? '#1a1a1a' : '#fff',
+      borderColor: isDark ? '#333' : '#e0e0e0',
+    },
+    title: {
+      color: isDark ? '#fff' : '#000',
+    },
+    categoryLabel: {
+      color: isDark ? '#ccc' : '#333',
+    },
+  };
+
+  return (
+    <RNView style={[styles.container, dynamicStyles.container]}>
+      <Text style={[styles.title, dynamicStyles.title]}>Stability by Type</Text>
+
+      {/* Legend */}
+      <RNView style={styles.legend}>
+        <LegendItem color={STABILITY_COLORS.understable} label="US" isDark={isDark} />
+        <LegendItem color={STABILITY_COLORS.stable} label="S" isDark={isDark} />
+        <LegendItem color={STABILITY_COLORS.overstable} label="OS" isDark={isDark} />
+      </RNView>
+
+      {data.map((item) => {
+        const total = item.understable + item.stable + item.overstable;
+        if (total === 0) return null;
+
+        return (
+          <RNView key={item.category} style={styles.row}>
+            <Text
+              style={[styles.categoryLabel, dynamicStyles.categoryLabel]}
+              numberOfLines={1}
+            >
+              {shortenCategory(item.category)}
+            </Text>
+            <RNView style={styles.barContainer}>
+              <RNView style={styles.stackedBar}>
+                {item.understable > 0 && (
+                  <RNView
+                    style={[
+                      styles.barSegment,
+                      {
+                        flex: item.understable,
+                        backgroundColor: STABILITY_COLORS.understable,
+                        borderTopLeftRadius: 4,
+                        borderBottomLeftRadius: 4,
+                      },
+                    ]}
+                  />
+                )}
+                {item.stable > 0 && (
+                  <RNView
+                    style={[
+                      styles.barSegment,
+                      {
+                        flex: item.stable,
+                        backgroundColor: STABILITY_COLORS.stable,
+                        borderTopLeftRadius: item.understable === 0 ? 4 : 0,
+                        borderBottomLeftRadius: item.understable === 0 ? 4 : 0,
+                        borderTopRightRadius: item.overstable === 0 ? 4 : 0,
+                        borderBottomRightRadius: item.overstable === 0 ? 4 : 0,
+                      },
+                    ]}
+                  />
+                )}
+                {item.overstable > 0 && (
+                  <RNView
+                    style={[
+                      styles.barSegment,
+                      {
+                        flex: item.overstable,
+                        backgroundColor: STABILITY_COLORS.overstable,
+                        borderTopRightRadius: 4,
+                        borderBottomRightRadius: 4,
+                      },
+                    ]}
+                  />
+                )}
+              </RNView>
+            </RNView>
+            <RNView style={styles.countsContainer}>
+              <Text style={[styles.count, { color: STABILITY_COLORS.understable }]}>
+                {item.understable}
+              </Text>
+              <Text style={[styles.count, { color: STABILITY_COLORS.stable }]}>
+                {item.stable}
+              </Text>
+              <Text style={[styles.count, { color: STABILITY_COLORS.overstable }]}>
+                {item.overstable}
+              </Text>
+            </RNView>
+          </RNView>
+        );
+      })}
+    </RNView>
+  );
+}
+
+function LegendItem({
+  color,
+  label,
+  isDark,
+}: {
+  color: string;
+  label: string;
+  isDark: boolean;
+}) {
+  return (
+    <RNView style={styles.legendItem}>
+      <RNView style={[styles.legendDot, { backgroundColor: color }]} />
+      <Text style={[styles.legendText, { color: isDark ? '#999' : '#666' }]}>
+        {label}
+      </Text>
+    </RNView>
+  );
+}
+
+// Shorten long category names for display
+function shortenCategory(category: string): string {
+  const map: Record<string, string> = {
+    'Distance Driver': 'Distance',
+    'Control Driver': 'Control',
+    'Hybrid Driver': 'Hybrid',
+    'Fairway Driver': 'Fairway',
+  };
+  return map[category] || category;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  legend: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 16,
+    marginBottom: 12,
+  },
+  legendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  legendDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginRight: 4,
+  },
+  legendText: {
+    fontSize: 10,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  categoryLabel: {
+    fontSize: 12,
+    fontWeight: '500',
+    width: 60,
+  },
+  barContainer: {
+    flex: 1,
+    marginHorizontal: 8,
+  },
+  stackedBar: {
+    flexDirection: 'row',
+    height: 12,
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  barSegment: {
+    height: '100%',
+  },
+  countsContainer: {
+    flexDirection: 'row',
+    width: 60,
+    justifyContent: 'space-between',
+  },
+  count: {
+    fontSize: 11,
+    fontWeight: '600',
+    width: 18,
+    textAlign: 'center',
+  },
+  emptyText: {
+    fontSize: 13,
+    color: '#999',
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
This adds the enhanced charts to the home page dashboard that were requested:

- **CategoryChart**: Shows disc type distribution (Distance Driver, Fairway, Midrange, Putter, etc.)
- **SpeedChart**: Bar chart showing speed distribution with color-coded bars by disc type
- **StabilityByCategoryChart**: Stacked bars showing understable/stable/overstable breakdown per category
- **Top Brand**: Updated display with trophy icon and "Most Popular Brand" label
- Dashboard moved below quick action buttons

## Changes
- Add CategoryChart, SpeedChart, StabilityByCategoryChart components
- Update bagStats utility with categoryDistribution, speedDistribution, stabilityByCategory
- Update BagDashboard to use new charts
- Add tests for new stats calculations

## Test plan
- [ ] Verify all charts display correctly on home page
- [ ] Test with various disc data combinations
- [ ] Verify dark mode styling
- [ ] Run test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)