### PR TITLE
fix: correct coverage caching path mismatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,18 +84,24 @@ jobs:
             echo "lines=$LINES"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Prepare coverage for caching
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p base-coverage
+          cp coverage/coverage-summary.json base-coverage/coverage-summary.json
+
       - name: Cache main branch coverage
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
-          path: coverage/coverage-summary.json
+          path: base-coverage/coverage-summary.json
           key: coverage-main-${{ github.sha }}
 
       - name: Update latest main coverage cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
-          path: coverage/coverage-summary.json
+          path: base-coverage/coverage-summary.json
           key: coverage-main-latest
 
   coverage-report:


### PR DESCRIPTION
## Summary
- Fixed mismatch between cache save path (`coverage/`) and restore path (`base-coverage/`)
- Added "Prepare coverage for caching" step that copies coverage to `base-coverage/` before saving
- Updated cache save steps to use `base-coverage/coverage-summary.json`

This matches the pattern already used in the API repository's test workflow.

## Test plan
- [ ] Merge this PR to main
- [ ] Wait for test workflow to run on main
- [ ] Verify cache is created with correct path
- [ ] Create a new PR and verify base coverage is properly restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)