### PR TITLE
feat: add category field to disc interfaces

### DIFF
--- a/app/(tabs)/my-bag.tsx
+++ b/app/(tabs)/my-bag.tsx
@@ -50,6 +50,7 @@ interface Disc {
   plastic?: string;
   weight?: number;
   color?: string;
+  category?: string;
   flight_numbers: FlightNumbers;
   reward_amount?: string;
   notes?: string;

--- a/utils/discCache.ts
+++ b/utils/discCache.ts
@@ -17,6 +17,7 @@ export interface CachedDisc {
   plastic?: string;
   weight?: number;
   color?: string;
+  category?: string;
   flight_numbers?: {
     speed: number | null;
     glide: number | null;


### PR DESCRIPTION
## Summary
- Added `category` field to `CachedDisc` interface in `utils/discCache.ts`
- Added `category` field to `Disc` interface in `app/(tabs)/my-bag.tsx`

This enables the CategoryChart on the home page dashboard to display disc type distribution once the API migration (discrapp/api#254) is deployed.

## Dependencies
- Requires discrapp/api#254 to be merged and deployed first

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] After API deployment, verify category distribution chart populates correctly
- [ ] Verify existing functionality still works for discs without category

🤖 Generated with [Claude Code](https://claude.com/claude-code)