### PR TITLE
fix(ci): install correct Maestro CLI for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,9 @@ jobs:
 
       - name: Install Maestro
         run: |
-          brew install maestro
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          export PATH="$PATH:$HOME/.maestro/bin"
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
           maestro --version
 
       - name: Start iOS Simulator


### PR DESCRIPTION
## Summary
- Fix Maestro installation in e2e workflow

## Problem
`brew install maestro` installs the wrong package - a GUI app called `Maestro.app` from `pedramamini/Maestro`, not the mobile.dev Maestro CLI.

```
🍺 maestro was successfully installed!
maestro: command not found
```

## Solution
Use the official mobile.dev install script:
```bash
curl -Ls "https://get.maestro.mobile.dev" | bash
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)