### PR TITLE
fix(ci): fix e2e simulator selection and code signing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,15 +52,17 @@ jobs:
 
       - name: Start iOS Simulator
         run: |
-          # Boot the default iOS simulator
-          xcrun simctl boot "iPhone 15 Pro" || true
+          # List available simulators and boot the first iPhone
+          SIMULATOR=$(xcrun simctl list devices available | grep -E "iPhone [0-9]+" | head -1 | sed 's/.*(\([^)]*\)).*/\1/')
+          echo "Booting simulator: $SIMULATOR"
+          xcrun simctl boot "$SIMULATOR" || true
           # Wait for simulator to be ready
           sleep 10
 
       - name: Build and install app
         run: |
-          # Build development client
-          npx expo run:ios --no-install --configuration Release
+          # Build for simulator (avoids code signing requirements)
+          npx expo run:ios --device simulator --configuration Release
         env:
           EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
           EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
## Summary
- Dynamically find available iPhone simulator instead of hardcoding "iPhone 15 Pro"
- Use `--device simulator` flag to avoid code signing requirements

## Problem
E2E tests were failing due to:
1. `Invalid device or device pair: iPhone 15 Pro` - macOS 15 runners have different simulator names
2. `No code signing certificates are available` - `expo run:ios` was trying to build for device

## Solution
1. Dynamically find first available iPhone simulator using `xcrun simctl list`
2. Use `--device simulator` flag to explicitly build for simulator (no signing needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)