### PR TITLE
fix(ci): pass simulator UDID to expo run:ios

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,18 +51,22 @@ jobs:
           maestro --version
 
       - name: Start iOS Simulator
+        id: simulator
         run: |
           # List available simulators and boot the first iPhone
-          SIMULATOR=$(xcrun simctl list devices available | grep -E "iPhone [0-9]+" | head -1 | sed 's/.*(\([^)]*\)).*/\1/')
-          echo "Booting simulator: $SIMULATOR"
-          xcrun simctl boot "$SIMULATOR" || true
+          SIMULATOR_UDID=$(xcrun simctl list devices available | grep -E "iPhone [0-9]+" | head -1 | sed 's/.*(\([^)]*\)).*/\1/')
+          SIMULATOR_NAME=$(xcrun simctl list devices available | grep -E "iPhone [0-9]+" | head -1 | sed 's/^[[:space:]]*//' | cut -d'(' -f1 | xargs)
+          echo "Booting simulator: $SIMULATOR_NAME ($SIMULATOR_UDID)"
+          xcrun simctl boot "$SIMULATOR_UDID" || true
+          echo "udid=$SIMULATOR_UDID" >> $GITHUB_OUTPUT
+          echo "name=$SIMULATOR_NAME" >> $GITHUB_OUTPUT
           # Wait for simulator to be ready
           sleep 10
 
       - name: Build and install app
         run: |
-          # Build for simulator (avoids code signing requirements)
-          npx expo run:ios --device simulator --configuration Release
+          # Build for the booted simulator (avoids code signing requirements)
+          npx expo run:ios --device "${{ steps.simulator.outputs.udid }}" --configuration Release
         env:
           EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
           EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
## Summary
Pass the actual simulator UDID to `--device` flag instead of literal "simulator"

## Problem
`expo run:ios --device simulator` fails with:
```
CommandError: No device UDID or name matching "simulator"
```

## Solution
Extract the simulator UDID in the "Start iOS Simulator" step and pass it to the build command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)