### PR TITLE
feat: add @ prefix to usernames in display

### DIFF
--- a/__tests__/recovery/recovery.test.tsx
+++ b/__tests__/recovery/recovery.test.tsx
@@ -1381,8 +1381,8 @@ describe('RecoveryDetailScreen', () => {
       const { getByText } = render(<RecoveryDetailScreen />);
 
       await waitFor(() => {
-        // When user_role is 'owner', the finder's name is displayed
-        expect(getByText('Finder User')).toBeTruthy();
+        // When user_role is 'owner', the finder's name is displayed with @ prefix
+        expect(getByText('@Finder User')).toBeTruthy();
       });
     });
   });

--- a/app/(tabs)/found-disc.tsx
+++ b/app/(tabs)/found-disc.tsx
@@ -979,7 +979,7 @@ export default function FoundDiscScreen() {
                         <Text style={styles.statusText}>{formatStatus(recovery.status)}</Text>
                       </View>
                       {recovery.status !== 'abandoned' && recovery.disc?.owner_display_name && (
-                        <Text style={styles.pendingOwner} numberOfLines={1} ellipsizeMode="tail">→ {recovery.disc.owner_display_name}</Text>
+                        <Text style={styles.pendingOwner} numberOfLines={1} ellipsizeMode="tail">→ {recovery.disc.owner_display_name === 'You' ? 'You' : `@${recovery.disc.owner_display_name}`}</Text>
                       )}
                     </View>
                   </View>
@@ -1192,7 +1192,7 @@ export default function FoundDiscScreen() {
             )}
             <View style={styles.ownerInfo}>
               <FontAwesome name="user" size={14} color="#666" />
-              <Text style={styles.ownerName} numberOfLines={1} ellipsizeMode="tail">{discInfo.owner_display_name}</Text>
+              <Text style={styles.ownerName} numberOfLines={1} ellipsizeMode="tail">{discInfo.owner_display_name === 'You' ? 'You' : `@${discInfo.owner_display_name}`}</Text>
             </View>
             {discInfo.reward_amount && discInfo.reward_amount > 0 && (
               <View style={styles.rewardBadge}>
@@ -1519,7 +1519,7 @@ export default function FoundDiscScreen() {
             <RNView style={styles.ownerAvatar}>
               <Text style={styles.ownerAvatarText}>{getInitial(ownerInfo.display_name)}</Text>
             </RNView>
-            <Text style={styles.ownerDisplayName}>{ownerInfo.display_name}</Text>
+            <Text style={styles.ownerDisplayName}>@{ownerInfo.display_name}</Text>
             <Text style={styles.ownerDiscCount}>
               {ownerInfo.disc_count} disc{ownerInfo.disc_count !== 1 ? 's' : ''} registered
             </Text>

--- a/app/recovery/[id].tsx
+++ b/app/recovery/[id].tsx
@@ -1049,7 +1049,7 @@ export default function RecoveryDetailScreen() {
           <RNView style={styles.personInfo}>
             <Text style={styles.personLabel}>Owner</Text>
             <Text style={[styles.personName, isOwner && styles.youText]} numberOfLines={1} ellipsizeMode="tail">
-              {isOwner ? 'You' : recovery.owner.display_name}
+              {isOwner ? 'You' : `@${recovery.owner.display_name}`}
             </Text>
           </RNView>
         </RNView>
@@ -1062,7 +1062,7 @@ export default function RecoveryDetailScreen() {
           <RNView style={styles.personInfo}>
             <Text style={styles.personLabel}>Finder</Text>
             <Text style={[styles.personName, !isOwner && styles.youText]} numberOfLines={1} ellipsizeMode="tail">
-              {!isOwner ? 'You' : recovery.finder.display_name}
+              {!isOwner ? 'You' : `@${recovery.finder.display_name}`}
             </Text>
           </RNView>
         </RNView>


### PR DESCRIPTION
## Summary
- Show usernames with @ prefix (e.g., @benniemosher) for better social UX
- Applied to:
  - Recovery screen: People section (Owner/Finder names)
  - Found disc screen: Owner names in disc cards and owner found modal
- The @ symbol is NOT shown when displaying "You" for the current user

## Test plan
- [x] All tests pass: `npm test -- --testPathPattern="recovery|found-disc"`
- [ ] Manual test: Check recovery screen shows @username in People section
- [ ] Manual test: Check found disc screen shows @username on owner cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)