### PR TITLE
fix: stay on recovery page after marking as recovered

### DIFF
--- a/app/recovery/[id].tsx
+++ b/app/recovery/[id].tsx
@@ -287,7 +287,8 @@ export default function RecoveryDetailScreen() {
               if (!response.ok) throw new Error(data.error || 'Failed to complete recovery');
 
               showSuccess('Your disc has been marked as recovered!');
-              router.back();
+              // Stay on page to show payment options instead of navigating away
+              fetchRecoveryDetails();
             } catch (err) {
               handleError(err, { operation: 'complete-recovery' });
             } finally {


### PR DESCRIPTION
## Summary
- After marking a disc as recovered, stay on the recovery details page instead of navigating back
- This allows the owner to immediately see and use the payment options (Venmo, card payment)
- The page refreshes to show the "Disc Recovered!" section with payment buttons

## Test plan
- [x] All tests pass: `npm test -- --testPathPattern="recovery"`
- [ ] Manual test: Mark a disc as recovered, verify you stay on the page and see payment options

🤖 Generated with [Claude Code](https://claude.com/claude-code)