### PR TITLE
fix(ci): extract simulator UDID using UUID pattern

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,9 +53,16 @@ jobs:
       - name: Start iOS Simulator
         id: simulator
         run: |
-          # List available simulators and boot the first iPhone
-          SIMULATOR_UDID=$(xcrun simctl list devices available | grep -E "iPhone [0-9]+" | head -1 | sed 's/.*(\([^)]*\)).*/\1/')
-          SIMULATOR_NAME=$(xcrun simctl list devices available | grep -E "iPhone [0-9]+" | head -1 | sed 's/^[[:space:]]*//' | cut -d'(' -f1 | xargs)
+          # List available simulators and find the first iPhone
+          # The format is: "    iPhone 15 Pro (UDID) (Shutdown)"
+          # We need to extract the UDID (first parenthesized value, which is a UUID)
+          DEVICE_LINE=$(xcrun simctl list devices available | grep -E "iPhone [0-9]+" | head -1)
+          echo "Found device line: $DEVICE_LINE"
+
+          # Extract UDID - it's the UUID pattern in parentheses
+          SIMULATOR_UDID=$(echo "$DEVICE_LINE" | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}')
+          SIMULATOR_NAME=$(echo "$DEVICE_LINE" | sed 's/^[[:space:]]*//' | cut -d'(' -f1 | xargs)
+
           echo "Booting simulator: $SIMULATOR_NAME ($SIMULATOR_UDID)"
           xcrun simctl boot "$SIMULATOR_UDID" || true
           echo "udid=$SIMULATOR_UDID" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- The previous sed command was extracting "Shutdown" from "(Shutdown)" instead of the actual UDID
- Now using `grep -oE` with UUID pattern (`[0-9A-F]{8}-[0-9A-F]{4}-...`) to correctly extract the simulator UDID
- Added debug output to show the found device line

## Root cause
The simulator list output looks like:
```
    iPhone 15 Pro (ABCD1234-5678-90EF-GHIJ-KLMNOPQRSTUV) (Shutdown)
```
The old sed pattern `s/.*(\([^)]*\)).*/\1/` was capturing the first `(...)` which was sometimes "(Shutdown)" instead of the UDID.

## Test plan
- [ ] E2E workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)