### PR TITLE
ci: add TypeScript type checking to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+
       - name: Run tests with coverage
         run: npm run test:coverage -- --coverageReporters=json-summary --coverageReporters=text
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,37 @@ pre-commit autoupdate           # Update hook versions
 
 ## Important Notes
 
+### TypeScript Type Checking - MANDATORY
+
+**CRITICAL:** All code MUST pass TypeScript strict mode checking. Before
+committing:
+
+```bash
+npx tsc --noEmit      # Must pass with no errors
+```
+
+**CI enforces this check** - PRs will fail if TypeScript errors are present.
+
+**Common type issues to avoid:**
+
+- Don't use `any` type - use proper types or `unknown` with type guards
+- Add explicit types to variables that TypeScript can't infer
+- When mocking in tests, ensure mock return types match expected types
+- Use type assertions (`as`) sparingly and only when you're certain of the type
+- For test mocks with varying return types, use union types in the mock generic
+
+**Example of properly typed test mock:**
+
+```typescript
+// Bad - TypeScript infers { error: null } so Error won't work
+const mockFn = jest.fn(() => Promise.resolve({ error: null }));
+
+// Good - Explicit union type allows both
+const mockFn = jest.fn<
+  Promise<{ error: Error | null }>
+>(() => Promise.resolve({ error: null }));
+```
+
 ### Test-Driven Development (TDD) - MANDATORY
 
 **CRITICAL:** All new code MUST be developed using Test-Driven Development:


### PR DESCRIPTION
## Summary
- Add TypeScript type checking step to CI workflow
- Update CLAUDE.md with TypeScript checking requirements

## Changes
- Add `npx tsc --noEmit` step to `.github/workflows/test.yml` before running tests
- Add "TypeScript Type Checking - MANDATORY" section to `CLAUDE.md` with:
  - Instructions to run type checking locally
  - Common type issues to avoid
  - Example of properly typed test mocks

## Why
TypeScript errors were accumulating in the codebase because they weren't being caught in CI. This PR ensures:
1. PRs cannot be merged with TypeScript errors
2. Developers know to check types before committing
3. Best practices for typing test mocks are documented

## Test plan
- [x] Run `npx tsc --noEmit` locally - passes
- [x] CI will run type check before tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)