### PR TITLE
feat: add missing common plastic types (#258)

### DIFF
--- a/constants/plasticTypes.ts
+++ b/constants/plasticTypes.ts
@@ -22,6 +22,7 @@ export const PLASTIC_TYPES: Record<string, string[]> = {
     'Color Glow',
     'Blizzard Champion',
     'Echo Star',
+    'Factory Second',
   ],
   Discraft: [
     'ESP',
@@ -149,6 +150,7 @@ export const PLASTIC_TYPES: Record<string, string[]> = {
     '500',
     '750',
     '750G',
+    'Pro Flex',
   ],
   'Infinite Discs': [
     'I-Blend',


### PR DESCRIPTION
## Summary
- Added **Factory Second** to Innova plastic types
- Added **Pro Flex** to Prodigy plastic types

Closes #258

## Test plan
- [ ] Verify Factory Second appears in plastic dropdown when Innova is selected
- [ ] Verify Pro Flex appears in plastic dropdown when Prodigy is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)