### PR TITLE
feat: add support for contribution_approved notifications

### DIFF
--- a/__tests__/tabs/notifications.test.tsx
+++ b/__tests__/tabs/notifications.test.tsx
@@ -1592,4 +1592,61 @@ describe('NotificationsScreen', () => {
       expect(() => fireEvent.press(getByText('Test'))).not.toThrow();
     });
   });
+
+  describe('contribution_approved notifications', () => {
+    it('displays contribution_approved notifications correctly', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          notifications: [{
+            id: 'n1',
+            type: 'contribution_approved',
+            title: 'Plastic Type Approved!',
+            body: 'Your submitted plastic type "Halo Star" for Innova has been approved. Thanks for contributing!',
+            data: { plastic_type_id: 'plastic-1' },
+            read: false,
+            created_at: new Date().toISOString(),
+          }],
+          unread_count: 1,
+        }),
+      });
+
+      const { getByText } = render(<NotificationsScreen />);
+
+      await waitFor(() => {
+        expect(getByText('Plastic Type Approved!')).toBeTruthy();
+        expect(getByText(/Halo Star/)).toBeTruthy();
+      });
+    });
+
+    it('does not navigate when contribution_approved notification is pressed', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          notifications: [{
+            id: 'n1',
+            type: 'contribution_approved',
+            title: 'Plastic Type Approved!',
+            body: 'Your contribution was approved',
+            data: { plastic_type_id: 'plastic-1' },
+            read: true, // Already read to avoid mark-as-read call
+            created_at: new Date().toISOString(),
+          }],
+          unread_count: 0,
+        }),
+      });
+
+      const { getByText } = render(<NotificationsScreen />);
+
+      await waitFor(() => {
+        expect(getByText('Plastic Type Approved!')).toBeTruthy();
+      });
+
+      // Press the notification - should not navigate anywhere
+      fireEvent.press(getByText('Plastic Type Approved!'));
+
+      // Should not navigate since contribution_approved has no target screen
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -20,13 +20,14 @@ import { useColorScheme } from '@/components/useColorScheme';
 
 interface Notification {
   id: string;
-  type: 'disc_found' | 'meetup_proposed' | 'meetup_accepted' | 'meetup_declined' | 'disc_recovered' | 'disc_surrendered';
+  type: 'disc_found' | 'meetup_proposed' | 'meetup_accepted' | 'meetup_declined' | 'disc_recovered' | 'disc_surrendered' | 'contribution_approved';
   title: string;
   body: string;
   data: {
     recovery_event_id?: string;
     disc_id?: string;
     proposal_id?: string;
+    plastic_type_id?: string;
   };
   read: boolean;
   created_at: string;
@@ -39,6 +40,7 @@ const NOTIFICATION_ICONS: Record<string, React.ComponentProps<typeof FontAwesome
   meetup_declined: 'times-circle',
   disc_recovered: 'trophy',
   disc_surrendered: 'gift',
+  contribution_approved: 'star',
 };
 
 const NOTIFICATION_COLORS: Record<string, string> = {
@@ -48,6 +50,7 @@ const NOTIFICATION_COLORS: Record<string, string> = {
   meetup_declined: '#E74C3C',
   disc_recovered: '#10b981',
   disc_surrendered: '#9B59B6',
+  contribution_approved: '#F1C40F',
 };
 
 // Memoized separator component for FlatList


### PR DESCRIPTION
## Summary
- Adds `contribution_approved` notification type for when admins approve user-submitted plastic types
- Displays with a yellow star icon
- Clicking the notification marks it as read (no navigation since there's no target screen)

## Test plan
- [ ] Submit a new plastic type
- [ ] Have admin approve it
- [ ] Verify notification appears with star icon
- [ ] Click notification - should mark as read but not navigate

🤖 Generated with [Claude Code](https://claude.com/claude-code)