### PR TITLE
feat: add QR code scanning to link sticker screen

### DIFF
--- a/__tests__/link-sticker/link-sticker.test.tsx
+++ b/__tests__/link-sticker/link-sticker.test.tsx
@@ -3,6 +3,13 @@ import { render, waitFor, fireEvent } from '@testing-library/react-native';
 import { Alert } from 'react-native';
 import LinkStickerScreen from '../../app/link-sticker';
 
+// Mock expo-camera
+const mockRequestPermission = jest.fn();
+jest.mock('expo-camera', () => ({
+  CameraView: 'CameraView',
+  useCameraPermissions: () => [{ granted: false }, mockRequestPermission],
+}));
+
 // Mock expo-router
 const mockBack = jest.fn();
 const mockReplace = jest.fn();
@@ -48,7 +55,7 @@ describe('LinkStickerScreen', () => {
     const { getByText } = render(<LinkStickerScreen />);
 
     await waitFor(() => {
-      expect(getByText('Enter Sticker Code')).toBeTruthy();
+      expect(getByText('Link Your Sticker')).toBeTruthy();
     });
   });
 
@@ -106,7 +113,7 @@ describe('LinkStickerScreen', () => {
     const { getByText } = render(<LinkStickerScreen />);
 
     await waitFor(() => {
-      expect(getByText('Find the code printed on your sticker and enter it below')).toBeTruthy();
+      expect(getByText('Scan the QR code on your sticker or enter the code manually')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## Summary

- Add camera QR code scanning option to the Link Sticker screen
- Users can now scan the QR code on their sticker instead of manually typing the code
- Reuses the same scanner UI pattern from the found-disc screen

## Changes

- Added `CameraView` from `expo-camera` for QR scanning
- Added "Scan QR Code" button with "or enter manually" divider  
- Auto-verifies the code after scanning
- Updated tests for new UI and scanning functionality

## Test plan

- [x] Unit tests pass (34 tests)
- [x] TypeScript compilation passes
- [ ] Manual test: scan a sticker QR code
- [ ] Manual test: deny camera permission shows alert
- [ ] Manual test: cancel scanning returns to input screen

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)