### PR TITLE
feat: use AI-detected disc type from photo identification

### DIFF
--- a/__tests__/hooks/useDiscIdentification.test.tsx
+++ b/__tests__/hooks/useDiscIdentification.test.tsx
@@ -35,6 +35,7 @@ describe('useDiscIdentification', () => {
   const mockIdentification: DiscIdentification = {
     manufacturer: 'Innova',
     mold: 'Destroyer',
+    disc_type: 'Distance Driver',
     confidence: 0.92,
     raw_text: 'INNOVA DESTROYER 12 5 -1 3',
     flight_numbers: {

--- a/app/add-disc.tsx
+++ b/app/add-disc.tsx
@@ -519,8 +519,8 @@ export default function AddDiscScreen() {
 
     // If we have a catalog match, use its flight numbers (more reliable)
     if (catalog_match) {
-      // Use API category or infer from speed
-      const matchCategory = catalog_match.category || inferCategoryFromSpeed(catalog_match.speed);
+      // Priority: 1) AI-detected disc_type (read from disc), 2) catalog category, 3) infer from speed
+      const matchCategory = identification.disc_type || catalog_match.category || inferCategoryFromSpeed(catalog_match.speed);
       if (matchCategory) setCategory(matchCategory);
       if (catalog_match.speed !== null) setSpeed(catalog_match.speed.toString());
       if (catalog_match.glide !== null) setGlide(catalog_match.glide.toString());
@@ -528,12 +528,16 @@ export default function AddDiscScreen() {
       if (catalog_match.fade !== null) setFade(catalog_match.fade.toString());
     } else if (identification.flight_numbers) {
       // Fall back to AI-detected flight numbers
-      const inferredCategory = inferCategoryFromSpeed(identification.flight_numbers.speed);
-      if (inferredCategory) setCategory(inferredCategory);
+      // Priority: 1) AI-detected disc_type (read from disc), 2) infer from speed
+      const discCategory = identification.disc_type || inferCategoryFromSpeed(identification.flight_numbers.speed);
+      if (discCategory) setCategory(discCategory);
       if (identification.flight_numbers.speed !== null) setSpeed(identification.flight_numbers.speed.toString());
       if (identification.flight_numbers.glide !== null) setGlide(identification.flight_numbers.glide.toString());
       if (identification.flight_numbers.turn !== null) setTurn(identification.flight_numbers.turn.toString());
       if (identification.flight_numbers.fade !== null) setFade(identification.flight_numbers.fade.toString());
+    } else if (identification.disc_type) {
+      // No catalog match and no flight numbers, but we have AI-detected disc_type
+      setCategory(identification.disc_type);
     }
 
     setShowIdentificationResult(false);

--- a/hooks/useDiscIdentification.ts
+++ b/hooks/useDiscIdentification.ts
@@ -5,6 +5,7 @@ import { handleError } from '@/lib/errorHandler';
 export interface DiscIdentification {
   manufacturer: string | null;
   mold: string | null;
+  disc_type: string | null;
   confidence: number;
   raw_text: string;
   flight_numbers: {


### PR DESCRIPTION
## Summary
- Add disc_type field to DiscIdentification interface to consume new API field
- Update applyIdentificationResult to prioritize AI-detected disc_type
- Fall back to catalog category or speed-based inference only if disc_type not detected

## Background
Issue #252 reported that the AI was selecting incorrect disc types (e.g., identifying a Hybrid Driver as a Distance Driver). The mobile app was inferring category only from speed, which doesn't support categories like Hybrid Driver, Control Driver, or Approach.

## Solution
The API now detects disc_type from printed text on the disc (e.g., DISTANCE DRIVER, HYBRID DRIVER). This PR updates the mobile app to use this AI-detected type as the primary source:

1. AI-detected disc_type (highest priority - read from disc)
2. Catalog match category (if no disc_type detected)
3. Speed-based inference (fallback)

## Dependencies
- Requires API PR #279 to be merged first (adds disc_type to API response)

## Test plan
- [x] Run useDiscIdentification tests
- [ ] Test with disc photos that have printed disc types
- [ ] Verify correct categorization for hybrid/control drivers

Part of #252