### PR TITLE
fix: Fill My Bag QA improvements

### DIFF
--- a/app/disc-recommendations.tsx
+++ b/app/disc-recommendations.tsx
@@ -182,6 +182,15 @@ export default function DiscRecommendationsScreen() {
           <FontAwesome name="refresh" size={20} color="#fff" style={{ marginRight: 8 }} />
           <Text style={styles.actionButtonText}>New Analysis</Text>
         </Pressable>
+
+        {/* Back Button */}
+        <Pressable
+          style={[styles.backButtonBottom, dynamicStyles.card]}
+          onPress={() => router.back()}
+        >
+          <FontAwesome name="chevron-left" size={16} color={textColor} style={{ marginRight: 8 }} />
+          <Text style={[styles.backButtonBottomText, dynamicStyles.text]}>Back to My Bag</Text>
+        </Pressable>
       </ScrollView>
     );
   };
@@ -352,5 +361,19 @@ const styles = StyleSheet.create({
   },
   tryAnotherButton: {
     marginTop: 8,
+  },
+  backButtonBottom: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginTop: 12,
+  },
+  backButtonBottomText: {
+    fontSize: 16,
+    fontWeight: '500',
   },
 });

--- a/components/BagAnalysisCard.tsx
+++ b/components/BagAnalysisCard.tsx
@@ -76,19 +76,25 @@ export default function BagAnalysisCard({
 
       {/* Speed Coverage */}
       <RNView style={[styles.section, dynamicStyles.sectionBorder]}>
-        <Text style={[styles.sectionTitle, dynamicStyles.text]}>Speed Coverage</Text>
-        <Text style={[styles.speedRange, dynamicStyles.secondaryText]}>
-          Speed {speed_coverage.min} - {speed_coverage.max}
-        </Text>
-        {speed_coverage.gaps.length > 0 && (
-          <RNView style={styles.speedGaps}>
-            {speed_coverage.gaps.map((gap, index) => (
-              <RNView key={index} style={styles.speedGapBadge}>
-                <Text style={styles.speedGapText}>Gap: {gap.from}-{gap.to}</Text>
+        <RNView style={styles.speedCoverageRow}>
+          <Text style={[styles.sectionTitle, styles.speedCoverageTitle, dynamicStyles.text]}>
+            Speed Coverage
+          </Text>
+          <RNView style={styles.speedCoverageRight}>
+            <Text style={[styles.speedRange, dynamicStyles.secondaryText]}>
+              {speed_coverage.min} - {speed_coverage.max}
+            </Text>
+            {speed_coverage.gaps.length > 0 && (
+              <RNView style={styles.speedGaps}>
+                {speed_coverage.gaps.map((gap, index) => (
+                  <RNView key={index} style={styles.speedGapBadge}>
+                    <Text style={styles.speedGapText}>Gap: {gap.from}-{gap.to}</Text>
+                  </RNView>
+                ))}
               </RNView>
-            ))}
+            )}
           </RNView>
-        )}
+        </RNView>
       </RNView>
 
       {/* Brand Preferences */}
@@ -116,13 +122,31 @@ export default function BagAnalysisCard({
             <RNView key={index} style={styles.stabilityRow}>
               <Text style={[styles.categoryName, dynamicStyles.text]}>{category.category}</Text>
               <RNView style={styles.stabilityBadges}>
-                <RNView style={[styles.stabilityBadge, styles.understableBadge]}>
+                <RNView
+                  style={[
+                    styles.stabilityBadge,
+                    styles.understableBadge,
+                    category.understable === 0 && styles.fadedBadge,
+                  ]}
+                >
                   <Text style={styles.stabilityBadgeText}>US: {category.understable}</Text>
                 </RNView>
-                <RNView style={[styles.stabilityBadge, styles.stableBadge]}>
+                <RNView
+                  style={[
+                    styles.stabilityBadge,
+                    styles.stableBadge,
+                    category.stable === 0 && styles.fadedBadge,
+                  ]}
+                >
                   <Text style={styles.stabilityBadgeText}>S: {category.stable}</Text>
                 </RNView>
-                <RNView style={[styles.stabilityBadge, styles.overstableBadge]}>
+                <RNView
+                  style={[
+                    styles.stabilityBadge,
+                    styles.overstableBadge,
+                    category.overstable === 0 && styles.fadedBadge,
+                  ]}
+                >
                   <Text style={styles.stabilityBadgeText}>OS: {category.overstable}</Text>
                 </RNView>
               </RNView>
@@ -193,14 +217,27 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginBottom: 8,
   },
+  speedCoverageRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  speedCoverageTitle: {
+    marginBottom: 0,
+  },
+  speedCoverageRight: {
+    alignItems: 'flex-end',
+  },
   speedRange: {
     fontSize: 14,
+    fontWeight: '600',
   },
   speedGaps: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 8,
-    marginTop: 8,
+    marginTop: 6,
+    justifyContent: 'flex-end',
   },
   speedGapBadge: {
     backgroundColor: 'rgba(231, 76, 60, 0.15)',
@@ -261,6 +298,9 @@ const styles = StyleSheet.create({
   },
   overstableBadge: {
     backgroundColor: '#E74C3C',
+  },
+  fadedBadge: {
+    opacity: 0.3,
   },
   gapsSection: {
     paddingTop: 12,

--- a/components/DiscRecommendationCard.tsx
+++ b/components/DiscRecommendationCard.tsx
@@ -22,6 +22,14 @@ const GAP_TYPE_LABELS: Record<string, string> = {
   category: 'Category Gap',
 };
 
+const PRIORITY_LABELS: Record<number, string> = {
+  1: 'Top Pick',
+  2: '2nd Pick',
+  3: '3rd Pick',
+  4: '4th Pick',
+  5: '5th Pick',
+};
+
 export default function DiscRecommendationCard({
   recommendation,
   isDark,
@@ -53,7 +61,9 @@ export default function DiscRecommendationCard({
       {/* Header with priority and gap type */}
       <RNView style={styles.cardHeader}>
         <RNView style={[styles.priorityBadge, dynamicStyles.priorityBadge]}>
-          <Text style={[styles.priorityText, { color: Colors.violet.primary }]}>#{priority}</Text>
+          <Text style={[styles.priorityText, { color: Colors.violet.primary }]}>
+            {PRIORITY_LABELS[priority] || `#${priority}`}
+          </Text>
         </RNView>
         <RNView style={styles.gapBadge}>
           <Text style={styles.gapText}>{GAP_TYPE_LABELS[gap_type] || gap_type}</Text>
@@ -148,7 +158,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   priorityText: {
-    fontSize: 12,
+    fontSize: 13,
     fontWeight: '700',
   },
   gapBadge: {


### PR DESCRIPTION
## Summary
Quick fixes from Fill My Bag QA session:

- **#279**: Fade out zero values in stability by category badges (opacity: 0.3)
- **#280**: Improve priority label readability - changed from "#1", "#2" to "Top Pick", "2nd Pick", etc.
- **#283**: Add back button at bottom of recommendations (after "New Analysis" button)
- **#278**: Show speed gap indicator aligned to the right side of the speed coverage section

## Changes
- `BagAnalysisCard.tsx`: Added `fadedBadge` style for zero values, restructured speed coverage layout
- `DiscRecommendationCard.tsx`: Added `PRIORITY_LABELS` mapping for readable labels
- `disc-recommendations.tsx`: Added "Back to My Bag" button at bottom

## Test plan
- [x] TypeScript compiles without errors
- [x] All existing tests pass (10/10)
- [ ] Visual verification of faded badges
- [ ] Visual verification of priority labels
- [ ] Visual verification of back button
- [ ] Visual verification of speed gap alignment

Part of #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)