### PR TITLE
feat: add trade-in candidates and fix dark mode contrast (#281)

### DIFF
--- a/__tests__/app/disc-recommendations.test.tsx
+++ b/__tests__/app/disc-recommendations.test.tsx
@@ -63,6 +63,17 @@ jest.mock('@/components/BagAnalysisCard', () => {
   };
 });
 
+jest.mock('@/components/TradeInCandidateCard', () => {
+  const { View, Text } = require('react-native');
+  return function MockTradeInCandidateCard({ candidate }: { candidate: { disc: { name: string | null; mold: string | null } } }) {
+    return (
+      <View testID="trade-in-candidate-card">
+        <Text>{candidate.disc.name || candidate.disc.mold}</Text>
+      </View>
+    );
+  };
+});
+
 const mockResult = {
   recommendations: [
     {
@@ -78,6 +89,19 @@ const mockResult = {
       gap_type: 'speed_range' as const,
       priority: 1,
       purchase_url: 'https://example.com/destroyer',
+    },
+  ],
+  trade_in_candidates: [
+    {
+      disc: {
+        id: 'user-disc-1',
+        name: 'Old Wraith',
+        manufacturer: 'Innova',
+        mold: 'Wraith',
+        plastic: 'Star',
+        flight_numbers: { speed: 11, glide: 5, turn: -1, fade: 3 },
+      },
+      reason: 'Similar flight to your Destroyer, may be redundant',
     },
   ],
   bag_analysis: {
@@ -199,6 +223,18 @@ describe('DiscRecommendationsScreen', () => {
       expect(getByText('Recommended Discs')).toBeTruthy();
       expect(getByTestId('disc-recommendation-card')).toBeTruthy();
       expect(getByText('New Analysis')).toBeTruthy();
+    });
+  });
+
+  it('shows trade-in candidates when present', async () => {
+    mockHookState.result = mockResult;
+
+    const { getByText, getByTestId } = render(<DiscRecommendationsScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Consider Trading')).toBeTruthy();
+      expect(getByText('These discs may be redundant in your bag')).toBeTruthy();
+      expect(getByTestId('trade-in-candidate-card')).toBeTruthy();
     });
   });
 

--- a/__tests__/hooks/useDiscRecommendations.test.tsx
+++ b/__tests__/hooks/useDiscRecommendations.test.tsx
@@ -49,6 +49,7 @@ describe('useDiscRecommendations', () => {
         purchase_url: 'https://infinitediscs.com/search?s=Innova%20Leopard&aff=test',
       },
     ],
+    trade_in_candidates: [],
     bag_analysis: {
       total_discs: 5,
       brand_preferences: [

--- a/app/disc-recommendations.tsx
+++ b/app/disc-recommendations.tsx
@@ -17,6 +17,7 @@ import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { useDiscRecommendations } from '@/hooks/useDiscRecommendations';
 import DiscRecommendationCard from '@/components/DiscRecommendationCard';
 import BagAnalysisCard from '@/components/BagAnalysisCard';
+import TradeInCandidateCard from '@/components/TradeInCandidateCard';
 
 type RecommendationCount = 1 | 3 | 5;
 
@@ -160,8 +161,8 @@ export default function DiscRecommendationsScreen() {
 
   const renderInitialState = () => (
     <View style={styles.centeredContent}>
-      <View style={[styles.iconContainer, { backgroundColor: 'rgba(127, 34, 206, 0.1)' }]}>
-        <FontAwesome name="lightbulb-o" size={48} color={Colors.violet.primary} />
+      <View style={[styles.iconContainer, { backgroundColor: isDark ? 'rgba(127, 34, 206, 0.3)' : 'rgba(127, 34, 206, 0.1)' }]}>
+        <FontAwesome name="lightbulb-o" size={48} color={isDark ? '#a78bfa' : Colors.violet.primary} />
       </View>
       <Text style={[styles.promptTitle, dynamicStyles.text]}>Fill Your Bag</Text>
       <Text style={[styles.promptSubtitle, dynamicStyles.secondaryText]}>
@@ -190,13 +191,16 @@ export default function DiscRecommendationsScreen() {
         <Animated.View
           style={[
             styles.loadingIconContainer,
-            { transform: [{ scale: pulseAnim }] },
+            {
+              transform: [{ scale: pulseAnim }],
+              backgroundColor: isDark ? 'rgba(127, 34, 206, 0.3)' : 'rgba(127, 34, 206, 0.1)',
+            },
           ]}
         >
           <FontAwesome
             name={currentStep.icon as keyof typeof FontAwesome.glyphMap}
             size={48}
-            color={Colors.violet.primary}
+            color={isDark ? '#a78bfa' : Colors.violet.primary}
           />
         </Animated.View>
 
@@ -211,7 +215,7 @@ export default function DiscRecommendationsScreen() {
               style={[
                 styles.loadingDot,
                 index === loadingStep && styles.loadingDotActive,
-                { backgroundColor: index === loadingStep ? Colors.violet.primary : isDark ? '#444' : '#ddd' },
+                { backgroundColor: index === loadingStep ? (isDark ? '#a78bfa' : Colors.violet.primary) : isDark ? '#444' : '#ddd' },
               ]}
             />
           ))}
@@ -250,7 +254,7 @@ export default function DiscRecommendationsScreen() {
   const renderResult = () => {
     if (!result) return null;
 
-    const { recommendations, bag_analysis, confidence, processing_time_ms } = result;
+    const { recommendations, trade_in_candidates, bag_analysis, confidence, processing_time_ms } = result;
 
     return (
       <ScrollView style={styles.resultScroll} contentContainerStyle={styles.resultContent}>
@@ -272,6 +276,23 @@ export default function DiscRecommendationsScreen() {
             onBuyPress={() => handleOpenLink(rec.purchase_url)}
           />
         ))}
+
+        {/* Trade-in Candidates */}
+        {trade_in_candidates && trade_in_candidates.length > 0 && (
+          <>
+            <Text style={[styles.sectionTitle, dynamicStyles.text]}>Consider Trading</Text>
+            <Text style={[styles.sectionSubtitle, dynamicStyles.secondaryText]}>
+              These discs may be redundant in your bag
+            </Text>
+            {trade_in_candidates.map((candidate, index) => (
+              <TradeInCandidateCard
+                key={candidate.disc.id || index}
+                candidate={candidate}
+                isDark={isDark}
+              />
+            ))}
+          </>
+        )}
 
         {/* Try Another Analysis Button */}
         <Pressable
@@ -395,21 +416,21 @@ const styles = StyleSheet.create({
   },
   countButtonSelected: {
     borderColor: Colors.violet.primary,
-    backgroundColor: 'rgba(127, 34, 206, 0.1)',
+    backgroundColor: 'rgba(127, 34, 206, 0.6)',
   },
   countButtonText: {
     fontSize: 24,
     fontWeight: '700',
   },
   countButtonTextSelected: {
-    color: Colors.violet.primary,
+    color: '#fff',
   },
   countButtonLabel: {
     fontSize: 12,
     marginTop: 2,
   },
   countButtonLabelSelected: {
-    color: Colors.violet.primary,
+    color: '#fff',
   },
   loadingIconContainer: {
     width: 96,
@@ -489,6 +510,11 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginBottom: 16,
     marginTop: 8,
+  },
+  sectionSubtitle: {
+    fontSize: 14,
+    marginTop: -12,
+    marginBottom: 16,
   },
   tryAnotherButton: {
     marginTop: 8,

--- a/components/DiscRecommendationCard.tsx
+++ b/components/DiscRecommendationCard.tsx
@@ -50,7 +50,10 @@ export default function DiscRecommendationCard({
       color: isDark ? '#999' : '#666',
     },
     priorityBadge: {
-      backgroundColor: isDark ? 'rgba(139, 92, 246, 0.2)' : Colors.violet[100],
+      backgroundColor: isDark ? 'rgba(139, 92, 246, 0.4)' : Colors.violet[100],
+    },
+    priorityText: {
+      color: isDark ? '#c4b5fd' : Colors.violet.primary,
     },
   };
 
@@ -61,7 +64,7 @@ export default function DiscRecommendationCard({
       {/* Header with priority and gap type */}
       <RNView style={styles.cardHeader}>
         <RNView style={[styles.priorityBadge, dynamicStyles.priorityBadge]}>
-          <Text style={[styles.priorityText, { color: Colors.violet.primary }]}>
+          <Text style={[styles.priorityText, dynamicStyles.priorityText]}>
             {PRIORITY_LABELS[priority] || `#${priority}`}
           </Text>
         </RNView>

--- a/components/TradeInCandidateCard.tsx
+++ b/components/TradeInCandidateCard.tsx
@@ -1,0 +1,164 @@
+import { StyleSheet, View as RNView } from 'react-native';
+import { Text } from '@/components/Themed';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import { TradeInCandidate } from '@/hooks/useDiscRecommendations';
+
+interface TradeInCandidateCardProps {
+  candidate: TradeInCandidate;
+  isDark: boolean;
+}
+
+export default function TradeInCandidateCard({
+  candidate,
+  isDark,
+}: TradeInCandidateCardProps) {
+  const { disc, reason } = candidate;
+  const flightNumbers = disc.flight_numbers;
+
+  const dynamicStyles = {
+    card: {
+      backgroundColor: isDark ? '#1e1e1e' : '#fff',
+      borderColor: isDark ? '#333' : '#e0e0e0',
+    },
+    text: {
+      color: isDark ? '#fff' : '#000',
+    },
+    secondaryText: {
+      color: isDark ? '#999' : '#666',
+    },
+  };
+
+  const discName = disc.name || `${disc.manufacturer || ''} ${disc.mold || ''}`.trim() || 'Unknown Disc';
+
+  return (
+    <RNView style={[styles.card, dynamicStyles.card]}>
+      {/* Trade-in icon and badge */}
+      <RNView style={styles.cardHeader}>
+        <RNView style={styles.tradeInBadge}>
+          <FontAwesome name="exchange" size={12} color="#E67E22" style={{ marginRight: 6 }} />
+          <Text style={styles.tradeInText}>Consider Trading</Text>
+        </RNView>
+      </RNView>
+
+      {/* Disc Info */}
+      <RNView style={styles.discInfo}>
+        <Text style={[styles.discName, dynamicStyles.text]}>{discName}</Text>
+        {disc.plastic && (
+          <Text style={[styles.discPlastic, dynamicStyles.secondaryText]}>{disc.plastic}</Text>
+        )}
+      </RNView>
+
+      {/* Flight Numbers */}
+      {flightNumbers && (
+        <RNView style={styles.flightNumbers}>
+          <RNView style={styles.flightNumberItem}>
+            <Text style={[styles.flightNumberValue, dynamicStyles.text]}>
+              {flightNumbers.speed}
+            </Text>
+            <Text style={[styles.flightNumberLabel, dynamicStyles.secondaryText]}>Speed</Text>
+          </RNView>
+          <RNView style={styles.flightNumberItem}>
+            <Text style={[styles.flightNumberValue, dynamicStyles.text]}>
+              {flightNumbers.glide}
+            </Text>
+            <Text style={[styles.flightNumberLabel, dynamicStyles.secondaryText]}>Glide</Text>
+          </RNView>
+          <RNView style={styles.flightNumberItem}>
+            <Text style={[styles.flightNumberValue, dynamicStyles.text]}>
+              {flightNumbers.turn}
+            </Text>
+            <Text style={[styles.flightNumberLabel, dynamicStyles.secondaryText]}>Turn</Text>
+          </RNView>
+          <RNView style={styles.flightNumberItem}>
+            <Text style={[styles.flightNumberValue, dynamicStyles.text]}>
+              {flightNumbers.fade}
+            </Text>
+            <Text style={[styles.flightNumberLabel, dynamicStyles.secondaryText]}>Fade</Text>
+          </RNView>
+        </RNView>
+      )}
+
+      {/* AI Reason */}
+      <RNView style={styles.reasonContainer}>
+        <FontAwesome
+          name="info-circle"
+          size={14}
+          color={isDark ? '#E67E22' : '#D35400'}
+          style={styles.reasonIcon}
+        />
+        <Text style={[styles.reasonText, dynamicStyles.secondaryText]}>{reason}</Text>
+      </RNView>
+    </RNView>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 16,
+    marginBottom: 12,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  tradeInBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'rgba(230, 126, 34, 0.15)',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  tradeInText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#E67E22',
+  },
+  discInfo: {
+    marginBottom: 12,
+  },
+  discName: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 2,
+  },
+  discPlastic: {
+    fontSize: 13,
+  },
+  flightNumbers: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    paddingVertical: 10,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: 'rgba(128, 128, 128, 0.2)',
+    marginBottom: 12,
+  },
+  flightNumberItem: {
+    alignItems: 'center',
+  },
+  flightNumberValue: {
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  flightNumberLabel: {
+    fontSize: 10,
+    marginTop: 2,
+  },
+  reasonContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+  },
+  reasonIcon: {
+    marginRight: 8,
+    marginTop: 2,
+  },
+  reasonText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+});

--- a/hooks/useDiscRecommendations.ts
+++ b/hooks/useDiscRecommendations.ts
@@ -26,6 +26,20 @@ export interface DiscRecommendation {
   purchase_url: string;
 }
 
+export interface TradeInDisc {
+  id: string;
+  name: string | null;
+  manufacturer: string | null;
+  mold: string | null;
+  plastic: string | null;
+  flight_numbers: FlightNumbers | null;
+}
+
+export interface TradeInCandidate {
+  disc: TradeInDisc;
+  reason: string;
+}
+
 export interface BrandPreference {
   manufacturer: string;
   count: number;
@@ -63,6 +77,7 @@ export interface BagAnalysis {
 
 export interface DiscRecommendationResult {
   recommendations: DiscRecommendation[];
+  trade_in_candidates: TradeInCandidate[];
   bag_analysis: BagAnalysis;
   confidence: number;
   processing_time_ms: number;
@@ -132,6 +147,7 @@ export function useDiscRecommendations(): UseDiscRecommendationsResult {
 
         const recommendationResult: DiscRecommendationResult = {
           recommendations: data.recommendations,
+          trade_in_candidates: data.trade_in_candidates || [],
           bag_analysis: data.bag_analysis,
           confidence: data.confidence,
           processing_time_ms: data.processing_time_ms,


### PR DESCRIPTION
## Summary
- Add trade-in candidates section to disc recommendations showing discs the AI suggests trading
- Fix dark mode contrast issues throughout the Fill My Bag feature
- Create TradeInCandidateCard component for displaying trade suggestions

## Changes
### Trade-in Candidates (#281)
- Updated `useDiscRecommendations` hook to include `trade_in_candidates` in result
- Created `TradeInCandidateCard` component with orange "Consider Trading" badge
- Added "Consider Trading" section in recommendations view

### Dark Mode Contrast Fixes
- **Count selector**: White text on darker purple background (60% opacity)
- **Lightbulb icon (initial state)**: Lighter purple icon (`#a78bfa`) on more visible background (30% opacity)
- **Loading icons**: Same treatment as initial state for consistency
- **Top Pick badge**: Lighter violet text (`#c4b5fd`) on more visible background (40% opacity)

## Test plan
- [ ] Verify count selector text is readable in dark mode with low brightness
- [ ] Verify lightbulb icon is visible in dark mode on initial screen
- [ ] Verify loading state icons are visible in dark mode
- [ ] Verify "Top Pick" badge text is readable in dark mode
- [ ] Verify trade-in candidates section appears when API returns candidates
- [ ] Run tests: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)