### PR TITLE
fix: shorten bottom navigation tab labels

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -126,14 +126,14 @@ export default function TabLayout() {
       <Tabs.Screen
         name="my-bag"
         options={{
-          title: 'My Bag',
+          title: 'Bag',
           tabBarIcon: ({ color }) => <TabBarIcon name="shopping-bag" color={color} />,
         }}
       />
       <Tabs.Screen
         name="found-disc"
         options={{
-          title: 'Found Disc',
+          title: 'Found',
           tabBarIcon: ({ color }) => <TabBarIcon name="search" color={color} />,
         }}
       />


### PR DESCRIPTION
## Summary
- Change "My Bag" → "Bag"
- Change "Found Disc" → "Found"

Shorter labels improve readability and visual balance in the navigation bar.

Closes #287

## Test plan
- [ ] Verify tab labels display as "Bag" and "Found"
- [ ] Confirm navigation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)