### PR TITLE
feat: add dismiss disc recommendation feature (#282)

### DIFF
--- a/__tests__/components/DiscRecommendationCard.test.tsx
+++ b/__tests__/components/DiscRecommendationCard.test.tsx
@@ -1,0 +1,339 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import DiscRecommendationCard from '../../components/DiscRecommendationCard';
+import { DiscRecommendation } from '@/hooks/useDiscRecommendations';
+
+const mockRecommendation: DiscRecommendation = {
+  disc: {
+    id: 'disc-123',
+    manufacturer: 'Innova',
+    mold: 'Destroyer',
+    category: 'Distance Driver',
+    stability: 'Overstable',
+    flight_numbers: {
+      speed: 12,
+      glide: 5,
+      turn: -1,
+      fade: 3,
+    },
+  },
+  reason: 'This disc fills the high-speed overstable slot in your bag',
+  gap_type: 'speed_range',
+  priority: 1,
+  purchase_url: 'https://example.com/destroyer',
+};
+
+describe('DiscRecommendationCard', () => {
+  const mockOnBuyPress = jest.fn();
+  const mockOnDismissPress = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders disc information correctly', () => {
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    expect(getByText('Destroyer')).toBeTruthy();
+    expect(getByText('Innova')).toBeTruthy();
+    expect(getByText('Distance Driver')).toBeTruthy();
+  });
+
+  it('renders flight numbers', () => {
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    expect(getByText('12')).toBeTruthy(); // Speed
+    expect(getByText('5')).toBeTruthy(); // Glide
+    expect(getByText('-1')).toBeTruthy(); // Turn
+    expect(getByText('3')).toBeTruthy(); // Fade
+    expect(getByText('Speed')).toBeTruthy();
+    expect(getByText('Glide')).toBeTruthy();
+    expect(getByText('Turn')).toBeTruthy();
+    expect(getByText('Fade')).toBeTruthy();
+  });
+
+  it('renders priority badge', () => {
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    expect(getByText('Top Pick')).toBeTruthy();
+  });
+
+  it('renders correct priority labels for different priorities', () => {
+    const priorities = [
+      { priority: 1, label: 'Top Pick' },
+      { priority: 2, label: '2nd Pick' },
+      { priority: 3, label: '3rd Pick' },
+      { priority: 4, label: '4th Pick' },
+      { priority: 5, label: '5th Pick' },
+    ];
+
+    priorities.forEach(({ priority, label }) => {
+      const rec = { ...mockRecommendation, priority };
+      const { getByText } = render(
+        <DiscRecommendationCard
+          recommendation={rec}
+          isDark={false}
+          onBuyPress={mockOnBuyPress}
+        />
+      );
+      expect(getByText(label)).toBeTruthy();
+    });
+  });
+
+  it('renders fallback priority label for unknown priority', () => {
+    const rec = { ...mockRecommendation, priority: 10 };
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={rec}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+    expect(getByText('#10')).toBeTruthy();
+  });
+
+  it('renders gap type badge', () => {
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    expect(getByText('Speed Gap')).toBeTruthy();
+  });
+
+  it('renders correct gap type labels', () => {
+    const gapTypes = [
+      { gap_type: 'speed_range', label: 'Speed Gap' },
+      { gap_type: 'stability', label: 'Stability Gap' },
+      { gap_type: 'category', label: 'Category Gap' },
+    ];
+
+    gapTypes.forEach(({ gap_type, label }) => {
+      const rec = { ...mockRecommendation, gap_type: gap_type as 'speed_range' | 'stability' | 'category' };
+      const { getByText } = render(
+        <DiscRecommendationCard
+          recommendation={rec}
+          isDark={false}
+          onBuyPress={mockOnBuyPress}
+        />
+      );
+      expect(getByText(label)).toBeTruthy();
+    });
+  });
+
+  it('renders stability badge', () => {
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    expect(getByText('Overstable')).toBeTruthy();
+  });
+
+  it('renders different stability badges', () => {
+    const stabilities = ['Understable', 'Stable', 'Overstable'];
+
+    stabilities.forEach((stability) => {
+      const rec = {
+        ...mockRecommendation,
+        disc: { ...mockRecommendation.disc, stability },
+      };
+      const { getByText } = render(
+        <DiscRecommendationCard
+          recommendation={rec}
+          isDark={false}
+          onBuyPress={mockOnBuyPress}
+        />
+      );
+      expect(getByText(stability)).toBeTruthy();
+    });
+  });
+
+  it('renders AI reason', () => {
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    expect(getByText('This disc fills the high-speed overstable slot in your bag')).toBeTruthy();
+  });
+
+  it('renders buy button and handles press', () => {
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    const buyButton = getByText('Buy on Infinite Discs');
+    expect(buyButton).toBeTruthy();
+
+    fireEvent.press(buyButton);
+    expect(mockOnBuyPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render dismiss button when onDismissPress is not provided', () => {
+    const { queryByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    expect(queryByText("Don't Show Again")).toBeNull();
+  });
+
+  it('renders dismiss button when onDismissPress is provided', () => {
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+        onDismissPress={mockOnDismissPress}
+      />
+    );
+
+    expect(getByText("Don't Show Again")).toBeTruthy();
+  });
+
+  it('handles dismiss button press', () => {
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+        onDismissPress={mockOnDismissPress}
+      />
+    );
+
+    fireEvent.press(getByText("Don't Show Again"));
+    expect(mockOnDismissPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows dismissing state when isDismissing is true', () => {
+    const { getByText, queryByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+        onDismissPress={mockOnDismissPress}
+        isDismissing={true}
+      />
+    );
+
+    expect(getByText('Dismissing...')).toBeTruthy();
+    expect(queryByText("Don't Show Again")).toBeNull();
+  });
+
+  it('applies dark mode styles', () => {
+    const { getByText } = render(
+      <DiscRecommendationCard
+        recommendation={mockRecommendation}
+        isDark={true}
+        onBuyPress={mockOnBuyPress}
+        onDismissPress={mockOnDismissPress}
+      />
+    );
+
+    // Just verify it renders without crashing in dark mode
+    expect(getByText('Destroyer')).toBeTruthy();
+    expect(getByText("Don't Show Again")).toBeTruthy();
+  });
+
+  it('handles disc without category', () => {
+    const recWithoutCategory = {
+      ...mockRecommendation,
+      disc: {
+        ...mockRecommendation.disc,
+        category: undefined,
+      },
+    };
+
+    const { getByText, queryByText } = render(
+      <DiscRecommendationCard
+        recommendation={recWithoutCategory}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    expect(getByText('Destroyer')).toBeTruthy();
+    expect(queryByText('Distance Driver')).toBeNull();
+  });
+
+  it('handles disc without stability', () => {
+    const recWithoutStability = {
+      ...mockRecommendation,
+      disc: {
+        ...mockRecommendation.disc,
+        stability: undefined,
+      },
+    };
+
+    const { getByText, queryByText } = render(
+      <DiscRecommendationCard
+        recommendation={recWithoutStability}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    expect(getByText('Destroyer')).toBeTruthy();
+    expect(queryByText('Overstable')).toBeNull();
+    expect(queryByText('Understable')).toBeNull();
+    expect(queryByText('Stable')).toBeNull();
+  });
+
+  it('handles disc without flight numbers', () => {
+    const recWithoutFlightNumbers = {
+      ...mockRecommendation,
+      disc: {
+        ...mockRecommendation.disc,
+        flight_numbers: undefined,
+      },
+    };
+
+    const { getByText, queryByText } = render(
+      <DiscRecommendationCard
+        recommendation={recWithoutFlightNumbers}
+        isDark={false}
+        onBuyPress={mockOnBuyPress}
+      />
+    );
+
+    expect(getByText('Destroyer')).toBeTruthy();
+    // Flight number labels should not be present
+    expect(queryByText('Speed')).toBeNull();
+    expect(queryByText('Glide')).toBeNull();
+  });
+});

--- a/__tests__/components/DiscRecommendationCard.test.tsx
+++ b/__tests__/components/DiscRecommendationCard.test.tsx
@@ -275,7 +275,7 @@ describe('DiscRecommendationCard', () => {
       ...mockRecommendation,
       disc: {
         ...mockRecommendation.disc,
-        category: undefined,
+        category: null,
       },
     };
 
@@ -296,7 +296,7 @@ describe('DiscRecommendationCard', () => {
       ...mockRecommendation,
       disc: {
         ...mockRecommendation.disc,
-        stability: undefined,
+        stability: null,
       },
     };
 
@@ -319,7 +319,7 @@ describe('DiscRecommendationCard', () => {
       ...mockRecommendation,
       disc: {
         ...mockRecommendation.disc,
-        flight_numbers: undefined,
+        flight_numbers: null,
       },
     };
 

--- a/__tests__/hooks/useDismissRecommendation.test.tsx
+++ b/__tests__/hooks/useDismissRecommendation.test.tsx
@@ -1,0 +1,267 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+// Mock Supabase
+const mockGetSession = jest.fn();
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: () => mockGetSession(),
+    },
+  },
+}));
+
+// Mock error handler
+jest.mock('@/lib/errorHandler', () => ({
+  handleError: jest.fn(),
+}));
+
+// Mock fetch
+global.fetch = jest.fn();
+
+import { useDismissRecommendation } from '@/hooks/useDismissRecommendation';
+import { handleError } from '@/lib/errorHandler';
+
+describe('useDismissRecommendation', () => {
+  const mockSession = {
+    access_token: 'test-token',
+    user: { id: 'user-123' },
+  };
+
+  const mockDismissResponse = {
+    success: true,
+    dismissed: {
+      id: 'dismiss-123',
+      disc_catalog_id: 'catalog-456',
+      dismissed_at: '2024-01-15T12:00:00Z',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSession.mockResolvedValue({ data: { session: mockSession } });
+    (global.fetch as jest.Mock).mockReset();
+  });
+
+  it('initializes with default state', () => {
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns error when not authenticated', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null } });
+
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    await act(async () => {
+      const success = await result.current.dismissDisc('catalog-456');
+      expect(success).toBe(false);
+    });
+
+    expect(result.current.error).toBe('You must be signed in to dismiss recommendations');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('sets loading state during request', async () => {
+    let resolveRequest: (value: Response) => void;
+    const requestPromise = new Promise<Response>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    (global.fetch as jest.Mock).mockImplementationOnce(() => requestPromise);
+
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    // Start the request
+    act(() => {
+      result.current.dismissDisc('catalog-456');
+    });
+
+    // Should be loading
+    expect(result.current.isLoading).toBe(true);
+
+    // Resolve the request
+    await act(async () => {
+      resolveRequest!({
+        ok: true,
+        json: () => Promise.resolve(mockDismissResponse),
+      } as Response);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('successfully dismisses a disc', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockDismissResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    await act(async () => {
+      const success = await result.current.dismissDisc('catalog-456');
+      expect(success).toBe(true);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('handles already dismissed disc gracefully', async () => {
+    const alreadyDismissedResponse = {
+      success: true,
+      message: 'Disc already dismissed',
+    };
+
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(alreadyDismissedResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    await act(async () => {
+      const success = await result.current.dismissDisc('catalog-456');
+      expect(success).toBe(true);
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it('handles API error response', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ error: 'Disc not found in catalog' }),
+      })
+    );
+
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    await act(async () => {
+      const success = await result.current.dismissDisc('nonexistent-disc');
+      expect(success).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Disc not found in catalog');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('handles network errors', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    await act(async () => {
+      const success = await result.current.dismissDisc('catalog-456');
+      expect(success).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(handleError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ operation: 'dismiss-disc-recommendation' })
+    );
+  });
+
+  it('calls correct API endpoint with auth header and disc_catalog_id', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockDismissResponse),
+      })
+    );
+
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    await act(async () => {
+      await result.current.dismissDisc('catalog-456');
+    });
+
+    const apiCall = (global.fetch as jest.Mock).mock.calls[0];
+    expect(apiCall[0]).toContain('/functions/v1/dismiss-disc-recommendation');
+    expect(apiCall[1].method).toBe('POST');
+    expect(apiCall[1].headers.Authorization).toBe('Bearer test-token');
+    expect(apiCall[1].headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(apiCall[1].body)).toEqual({ disc_catalog_id: 'catalog-456' });
+  });
+
+  it('handles 400 bad request error', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: 'disc_catalog_id is required' }),
+      })
+    );
+
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    await act(async () => {
+      const success = await result.current.dismissDisc('');
+      expect(success).toBe(false);
+    });
+
+    expect(result.current.error).toBe('disc_catalog_id is required');
+  });
+
+  it('handles 500 server error', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'Failed to dismiss recommendation' }),
+      })
+    );
+
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    await act(async () => {
+      const success = await result.current.dismissDisc('catalog-456');
+      expect(success).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Failed to dismiss recommendation');
+  });
+
+  it('clears error on new request', async () => {
+    // First request fails
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ error: 'Disc not found' }),
+      })
+    );
+
+    const { result } = renderHook(() => useDismissRecommendation());
+
+    await act(async () => {
+      await result.current.dismissDisc('bad-id');
+    });
+
+    expect(result.current.error).toBe('Disc not found');
+
+    // Second request succeeds
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockDismissResponse),
+      })
+    );
+
+    await act(async () => {
+      await result.current.dismissDisc('catalog-456');
+    });
+
+    // Error should be cleared
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/components/DiscRecommendationCard.tsx
+++ b/components/DiscRecommendationCard.tsx
@@ -8,6 +8,8 @@ interface DiscRecommendationCardProps {
   recommendation: DiscRecommendation;
   isDark: boolean;
   onBuyPress: () => void;
+  onDismissPress?: () => void;
+  isDismissing?: boolean;
 }
 
 const STABILITY_COLORS: Record<string, { bg: string; text: string }> = {
@@ -34,6 +36,8 @@ export default function DiscRecommendationCard({
   recommendation,
   isDark,
   onBuyPress,
+  onDismissPress,
+  isDismissing,
 }: DiscRecommendationCardProps) {
   const { disc, reason, gap_type, priority } = recommendation;
   const flightNumbers = disc.flight_numbers;
@@ -138,6 +142,25 @@ export default function DiscRecommendationCard({
         <Text style={styles.buyButtonText}>Buy on Infinite Discs</Text>
         <FontAwesome name="external-link" size={12} color="#fff" style={{ marginLeft: 8 }} />
       </Pressable>
+
+      {/* Dismiss Button */}
+      {onDismissPress && (
+        <Pressable
+          style={[styles.dismissButton, isDismissing && { opacity: 0.5 }]}
+          onPress={onDismissPress}
+          disabled={isDismissing}
+        >
+          <FontAwesome
+            name="ban"
+            size={14}
+            color={isDark ? '#888' : '#666'}
+            style={{ marginRight: 8 }}
+          />
+          <Text style={[styles.dismissButtonText, { color: isDark ? '#888' : '#666' }]}>
+            {isDismissing ? 'Dismissing...' : "Don't Show Again"}
+          </Text>
+        </Pressable>
+      )}
     </RNView>
   );
 }
@@ -248,5 +271,16 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 14,
     fontWeight: '600',
+  },
+  dismissButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 10,
+    marginTop: 8,
+  },
+  dismissButtonText: {
+    fontSize: 13,
+    fontWeight: '500',
   },
 });

--- a/hooks/useDismissRecommendation.ts
+++ b/hooks/useDismissRecommendation.ts
@@ -1,0 +1,82 @@
+import { useState, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+import { handleError } from '@/lib/errorHandler';
+
+interface DismissResult {
+  success: boolean;
+  message?: string;
+  dismissed?: {
+    id: string;
+    disc_catalog_id: string;
+    dismissed_at: string;
+  };
+}
+
+interface UseDismissRecommendationResult {
+  dismissDisc: (discCatalogId: string) => Promise<boolean>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Hook for dismissing disc recommendations so they won't be suggested again.
+ * Calls the dismiss-disc-recommendation edge function.
+ */
+export function useDismissRecommendation(): UseDismissRecommendationResult {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const dismissDisc = useCallback(async (discCatalogId: string): Promise<boolean> => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // Get session for authentication
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        setError('You must be signed in to dismiss recommendations');
+        return false;
+      }
+
+      // Call the dismiss-disc-recommendation endpoint
+      const response = await fetch(
+        `${process.env.EXPO_PUBLIC_SUPABASE_URL}/functions/v1/dismiss-disc-recommendation`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ disc_catalog_id: discCatalogId }),
+        }
+      );
+
+      const data: DismissResult = await response.json();
+
+      if (!response.ok) {
+        const errorMessage = (data as { error?: string }).error || 'Failed to dismiss recommendation';
+        console.error('Dismiss recommendation API error:', response.status, errorMessage);
+        setError(errorMessage);
+        return false;
+      }
+
+      // Success (including "already dismissed" case)
+      return true;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'An error occurred';
+      setError(errorMessage);
+      handleError(err, { operation: 'dismiss-disc-recommendation' });
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return {
+    dismissDisc,
+    isLoading,
+    error,
+  };
+}


### PR DESCRIPTION
## Summary
- Add database migration for `dismissed_disc_recommendations` table with RLS policies
- Add `dismiss-disc-recommendation` edge function to record user dismissals
- Update `get-disc-recommendations` to filter out previously dismissed discs

## Test plan
- [ ] Run `deno test --allow-all supabase/functions/dismiss-disc-recommendation/`
- [ ] Run `deno test --allow-all supabase/functions/get-disc-recommendations/`
- [ ] Apply migration to Supabase
- [ ] Test dismiss API endpoint manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)