### PR TITLE
fix: case-insensitive color lookup in ColorDot

### DIFF
--- a/components/BagDashboard.tsx
+++ b/components/BagDashboard.tsx
@@ -186,7 +186,11 @@ export default function BagDashboard({
 }
 
 function ColorDot({ color }: { color: string }) {
-  const hexColor = DISC_COLORS[color as keyof typeof DISC_COLORS] || '#666';
+  // Case-insensitive color lookup
+  const normalizedColor = Object.keys(DISC_COLORS).find(
+    (key) => key.toLowerCase() === color.toLowerCase()
+  ) as keyof typeof DISC_COLORS | undefined;
+  const hexColor = normalizedColor ? DISC_COLORS[normalizedColor] : '#666';
 
   if (hexColor === 'rainbow') {
     return (


### PR DESCRIPTION
## Summary
Fix color dots showing gray instead of the correct color when the color name in the database has different casing than expected.

## Problem
The `ColorDot` component did a case-sensitive lookup against `DISC_COLORS`:
```tsx
const hexColor = DISC_COLORS[color as keyof typeof DISC_COLORS] || '#666';
```

If the database stored "yellow" but `DISC_COLORS` has "Yellow", the lookup failed and showed gray (#666).

## Solution
Added case-insensitive matching:
```tsx
const normalizedColor = Object.keys(DISC_COLORS).find(
  (key) => key.toLowerCase() === color.toLowerCase()
) as keyof typeof DISC_COLORS | undefined;
const hexColor = normalizedColor ? DISC_COLORS[normalizedColor] : '#666';
```

Closes #295

## Test plan
- [ ] Colors in Bag Dashboard display correctly regardless of casing
- [ ] "Base Grip" plastic disc with yellow color shows yellow dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)