### PR TITLE
fix: clear user cache on sign out

### DIFF
--- a/__tests__/utils/clearUserCache.test.ts
+++ b/__tests__/utils/clearUserCache.test.ts
@@ -1,0 +1,63 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { clearUserCache } from '@/utils/clearUserCache';
+import { STORAGE_KEYS } from '@/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  multiRemove: jest.fn(),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockMultiRemove = AsyncStorage.multiRemove as jest.MockedFunction<
+  typeof AsyncStorage.multiRemove
+>;
+
+describe('clearUserCache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('removes all user data storage keys', async () => {
+    mockMultiRemove.mockResolvedValue(undefined);
+
+    await clearUserCache();
+
+    expect(mockMultiRemove).toHaveBeenCalledWith([
+      STORAGE_KEYS.DISC_CACHE,
+      STORAGE_KEYS.DISC_CACHE_TIMESTAMP,
+    ]);
+  });
+
+  it('logs debug message on success', async () => {
+    const { logger } = require('@/lib/logger');
+    mockMultiRemove.mockResolvedValue(undefined);
+
+    await clearUserCache();
+
+    expect(logger.debug).toHaveBeenCalledWith('User cache cleared');
+  });
+
+  it('logs error on failure', async () => {
+    const { logger } = require('@/lib/logger');
+    const error = new Error('Storage error');
+    mockMultiRemove.mockRejectedValue(error);
+
+    await clearUserCache();
+
+    expect(logger.error).toHaveBeenCalledWith('Error clearing user cache:', error);
+  });
+
+  it('does not clear biometric settings', async () => {
+    mockMultiRemove.mockResolvedValue(undefined);
+
+    await clearUserCache();
+
+    const callArgs = mockMultiRemove.mock.calls[0][0];
+    expect(callArgs).not.toContain(STORAGE_KEYS.BIOMETRIC_ENABLED);
+  });
+});

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ import { Platform } from 'react-native';
 import { supabase } from '@/lib/supabase';
 import { setUserContext, clearUserContext, captureError } from '@/lib/sentry';
 import { logger } from '@/lib/logger';
+import { clearUserCache } from '@/utils/clearUserCache';
 
 // Configure notification handler
 Notifications.setNotificationHandler({
@@ -280,6 +281,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setSession(null);
     setUser(null);
     clearUserContext();
+    // Clear cached user data to prevent next user from seeing previous user's data
+    await clearUserCache();
   };
 
   return (

--- a/utils/clearUserCache.ts
+++ b/utils/clearUserCache.ts
@@ -1,0 +1,28 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { STORAGE_KEYS } from '@/constants/storageKeys';
+import { logger } from '@/lib/logger';
+
+/**
+ * Storage keys that contain user-specific data and should be cleared on sign out.
+ * Device-specific settings (like biometric_enabled) are NOT included.
+ */
+const USER_DATA_KEYS = [
+  STORAGE_KEYS.DISC_CACHE,
+  STORAGE_KEYS.DISC_CACHE_TIMESTAMP,
+] as const;
+
+/**
+ * Clear all cached user data from AsyncStorage.
+ * Should be called on sign out to prevent the next user from seeing
+ * the previous user's data.
+ *
+ * Note: Device-specific settings (e.g., biometric preferences) are NOT cleared.
+ */
+export async function clearUserCache(): Promise<void> {
+  try {
+    await AsyncStorage.multiRemove([...USER_DATA_KEYS]);
+    logger.debug('User cache cleared');
+  } catch (error) {
+    logger.error('Error clearing user cache:', error);
+  }
+}


### PR DESCRIPTION
## Summary
Clear all user-specific cached data when signing out to prevent the next user from seeing the previous user's discs.

## Problem
When user A signs out and user B signs in, user B could briefly see user A's discs on the Home page and My Bag screen because the disc cache wasn't being cleared.

## Solution
- Added `clearUserCache` utility that removes all user-specific storage keys
- Call `clearUserCache()` in `signOut()` function
- Device-specific settings (biometric preferences) are NOT cleared

## Files Changed
- `utils/clearUserCache.ts` - New utility for clearing user data
- `contexts/AuthContext.tsx` - Call clearUserCache on sign out
- `__tests__/utils/clearUserCache.test.ts` - Tests for new utility

Closes #297

## Test plan
- [x] clearUserCache tests pass (4 tests)
- [x] TypeScript check passes
- [ ] Sign out clears disc cache
- [ ] New user sees empty/loading state, not previous user's data

🤖 Generated with [Claude Code](https://claude.com/claude-code)