### PR TITLE
fix: stay on recovery page after marking disc as retrieved

### DIFF
--- a/app/recovery/[id].tsx
+++ b/app/recovery/[id].tsx
@@ -378,7 +378,8 @@ export default function RecoveryDetailScreen() {
               if (!response.ok) throw new Error(data.error || 'Failed to mark as retrieved');
 
               showSuccess('Your disc has been marked as retrieved!');
-              router.back();
+              // Stay on page to show payment options instead of navigating away
+              fetchRecoveryDetails();
             } catch (err) {
               handleError(err, { operation: 'mark-retrieved' });
             } finally {


### PR DESCRIPTION
## Summary

- Fixed `handleMarkRetrieved` to stay on the recovery details page after the owner marks a dropped-off disc as retrieved
- Previously called `router.back()` which prevented owners from seeing payment options
- Now calls `fetchRecoveryDetails()` to refresh the page, matching the behavior of `handleCompleteRecovery`

## Test plan

- [x] Unit test updated to verify the page stays open and refreshes
- [ ] Manual test: As an owner with a dropped-off disc, tap "I Picked Up My Disc" and confirm - verify you stay on the recovery page and can see payment options

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)