### PR TITLE
feat: profile QA improvements (#298)

### DIFF
--- a/__tests__/auth/sign-up.test.tsx
+++ b/__tests__/auth/sign-up.test.tsx
@@ -64,6 +64,15 @@ const getButton = (getAllByText: (text: string) => any[], text: string) => {
   return elements[elements.length - 1];
 };
 
+// Helper to fill all required form fields
+const fillRequiredFields = (getByPlaceholderText: (text: string) => any) => {
+  fireEvent.changeText(getByPlaceholderText('Enter your email'), 'test@example.com');
+  fireEvent.changeText(getByPlaceholderText('Choose a username'), 'testuser');
+  fireEvent.changeText(getByPlaceholderText('Enter your phone number'), '1234567890');
+  fireEvent.changeText(getByPlaceholderText('Create a password (min 8 characters)'), 'password123');
+  fireEvent.changeText(getByPlaceholderText('Confirm your password'), 'password123');
+};
+
 describe('SignUp', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -147,15 +156,22 @@ describe('SignUp', () => {
 
     const { getAllByText, getByPlaceholderText } = render(<SignUp />);
 
-    fireEvent.changeText(getByPlaceholderText('Enter your email'), 'test@example.com');
-    fireEvent.changeText(getByPlaceholderText('Create a password (min 8 characters)'), 'password123');
-    fireEvent.changeText(getByPlaceholderText('Confirm your password'), 'password123');
+    fillRequiredFields(getByPlaceholderText);
     await act(async () => {
       fireEvent.press(getButton(getAllByText, 'Create Account'));
     });
 
     await waitFor(() => {
-      expect(mockSignUp).toHaveBeenCalledWith('test@example.com', 'password123');
+      expect(mockSignUp).toHaveBeenCalledWith(
+        'test@example.com',
+        'password123',
+        expect.objectContaining({
+          username: 'testuser',
+          phone_number: '1234567890',
+          throwing_hand: 'right',
+          preferred_throw_style: 'backhand',
+        })
+      );
     });
   });
 
@@ -164,9 +180,7 @@ describe('SignUp', () => {
 
     const { getAllByText, getByPlaceholderText } = render(<SignUp />);
 
-    fireEvent.changeText(getByPlaceholderText('Enter your email'), 'test@example.com');
-    fireEvent.changeText(getByPlaceholderText('Create a password (min 8 characters)'), 'password123');
-    fireEvent.changeText(getByPlaceholderText('Confirm your password'), 'password123');
+    fillRequiredFields(getByPlaceholderText);
     await act(async () => {
       fireEvent.press(getButton(getAllByText, 'Create Account'));
     });
@@ -186,6 +200,8 @@ describe('SignUp', () => {
     const { getAllByText, getByPlaceholderText } = render(<SignUp />);
 
     fireEvent.changeText(getByPlaceholderText('Enter your email'), 'existing@example.com');
+    fireEvent.changeText(getByPlaceholderText('Choose a username'), 'testuser');
+    fireEvent.changeText(getByPlaceholderText('Enter your phone number'), '1234567890');
     fireEvent.changeText(getByPlaceholderText('Create a password (min 8 characters)'), 'password123');
     fireEvent.changeText(getByPlaceholderText('Confirm your password'), 'password123');
     await act(async () => {
@@ -205,9 +221,7 @@ describe('SignUp', () => {
 
     const { getAllByText, getByPlaceholderText } = render(<SignUp />);
 
-    fireEvent.changeText(getByPlaceholderText('Enter your email'), 'test@example.com');
-    fireEvent.changeText(getByPlaceholderText('Create a password (min 8 characters)'), 'password123');
-    fireEvent.changeText(getByPlaceholderText('Confirm your password'), 'password123');
+    fillRequiredFields(getByPlaceholderText);
     await act(async () => {
       fireEvent.press(getButton(getAllByText, 'Create Account'));
     });
@@ -296,6 +310,8 @@ describe('SignUp', () => {
     const { getAllByText, getByPlaceholderText } = render(<SignUp />);
 
     fireEvent.changeText(getByPlaceholderText('Enter your email'), '  test@example.com  ');
+    fireEvent.changeText(getByPlaceholderText('Choose a username'), 'testuser');
+    fireEvent.changeText(getByPlaceholderText('Enter your phone number'), '1234567890');
     fireEvent.changeText(getByPlaceholderText('Create a password (min 8 characters)'), 'password123');
     fireEvent.changeText(getByPlaceholderText('Confirm your password'), 'password123');
 
@@ -304,7 +320,11 @@ describe('SignUp', () => {
       await Promise.resolve(); // Allow promises to resolve
     });
 
-    expect(mockSignUp).toHaveBeenCalledWith('test@example.com', 'password123');
+    expect(mockSignUp).toHaveBeenCalledWith(
+      'test@example.com',
+      'password123',
+      expect.objectContaining({ username: 'testuser' })
+    );
   });
 
   // Skip - test isolation issues (passes individually, fails when run together)
@@ -364,9 +384,7 @@ describe('SignUp', () => {
 
     const { getAllByText, getByPlaceholderText } = render(<SignUp />);
 
-    fireEvent.changeText(getByPlaceholderText('Enter your email'), 'test@example.com');
-    fireEvent.changeText(getByPlaceholderText('Create a password (min 8 characters)'), 'password123');
-    fireEvent.changeText(getByPlaceholderText('Confirm your password'), 'password123');
+    fillRequiredFields(getByPlaceholderText);
     await act(async () => {
       fireEvent.press(getButton(getAllByText, 'Create Account'));
     });

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -15,28 +15,58 @@ import {
 } from 'react-native';
 import { Link, router } from 'expo-router';
 import { useAuth } from '@/contexts/AuthContext';
-import { validateSignUpForm } from '@/lib/validation';
+import { validateFullSignUpForm, SignUpFormErrors } from '@/lib/validation';
 import { handleError } from '@/lib/errorHandler';
 import Colors from '@/constants/Colors';
 
 const logo = require('@/assets/images/logo.png');
 
+type ThrowingHand = 'right' | 'left';
+type ThrowStyle = 'backhand' | 'forehand' | 'both';
+
 export default function SignUp() {
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
   const { signUp } = useAuth();
+
+  // Form state
   const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [usernameManuallyEdited, setUsernameManuallyEdited] = useState(false);
+  const [fullName, setFullName] = useState('');
+  const [phoneNumber, setPhoneNumber] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [throwingHand, setThrowingHand] = useState<ThrowingHand>('right');
+  const [preferredThrowStyle, setPreferredThrowStyle] = useState<ThrowStyle>('backhand');
+
   const [loading, setLoading] = useState(false);
-  const [errors, setErrors] = useState<{
-    email?: string;
-    password?: string;
-    confirmPassword?: string;
-  }>({});
+  const [errors, setErrors] = useState<SignUpFormErrors>({});
+
+  // Auto-populate username from email
+  useEffect(() => {
+    if (!usernameManuallyEdited && email.includes('@')) {
+      const emailPrefix = email.split('@')[0];
+      // Clean up the prefix to be a valid username
+      const cleanUsername = emailPrefix
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]/g, '')
+        .substring(0, 30);
+      setUsername(cleanUsername);
+    }
+  }, [email, usernameManuallyEdited]);
 
   const validateForm = () => {
-    const newErrors = validateSignUpForm(email, password, confirmPassword);
+    const newErrors = validateFullSignUpForm({
+      email,
+      password,
+      confirmPassword,
+      username,
+      fullName,
+      phoneNumber,
+      throwingHand,
+      preferredThrowStyle,
+    });
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -48,12 +78,18 @@ export default function SignUp() {
 
     setLoading(true);
     try {
-      const { error } = await signUp(email.trim(), password);
+      const metadata = {
+        username: username.trim(),
+        full_name: fullName.trim() || undefined,
+        phone_number: phoneNumber.trim().replace(/[\s\-\(\)]/g, ''),
+        throwing_hand: throwingHand,
+        preferred_throw_style: preferredThrowStyle,
+      };
+      const { error } = await signUp(email.trim(), password, metadata);
 
       if (error) {
         handleError(error, { operation: 'sign-up' });
       } else {
-        // Keep as Alert since it navigates on dismiss
         Alert.alert(
           'Success',
           'Account created! You can now sign in.',
@@ -96,6 +132,20 @@ export default function SignUp() {
     link: {
       color: isDark ? Colors.violet[400] : Colors.violet.primary,
     },
+    toggleButton: {
+      backgroundColor: isDark ? '#1e1e1e' : '#f5f5f5',
+      borderColor: isDark ? '#333' : '#ddd',
+    },
+    toggleButtonActive: {
+      backgroundColor: Colors.violet.primary,
+      borderColor: Colors.violet.primary,
+    },
+    toggleText: {
+      color: isDark ? '#999' : '#666',
+    },
+    toggleTextActive: {
+      color: '#fff',
+    },
   };
 
   return (
@@ -121,6 +171,7 @@ export default function SignUp() {
           <Text style={[styles.subtitle, dynamicStyles.subtitle]}>Sign up to get started</Text>
 
           <View style={styles.form}>
+            {/* Email - First so username can auto-populate */}
             <View style={styles.inputContainer}>
               <Text style={[styles.label, dynamicStyles.label]}>Email</Text>
               <TextInput
@@ -136,6 +187,8 @@ export default function SignUp() {
                 }}
                 autoCapitalize="none"
                 keyboardType="email-address"
+                textContentType="emailAddress"
+                autoComplete="email"
                 editable={!loading}
               />
               {errors.email && (
@@ -143,6 +196,179 @@ export default function SignUp() {
               )}
             </View>
 
+            {/* Username - Auto-populated from email */}
+            <View style={styles.inputContainer}>
+              <Text style={[styles.label, dynamicStyles.label]}>Username</Text>
+              <TextInput
+                style={[styles.input, dynamicStyles.input, errors.username && styles.inputError]}
+                placeholder="Choose a username"
+                placeholderTextColor={isDark ? '#666' : '#999'}
+                value={username}
+                onChangeText={(text) => {
+                  setUsername(text);
+                  setUsernameManuallyEdited(true);
+                  if (errors.username) {
+                    setErrors({ ...errors, username: undefined });
+                  }
+                }}
+                autoCapitalize="none"
+                autoCorrect={false}
+                textContentType="username"
+                autoComplete="username"
+                editable={!loading}
+              />
+              {errors.username && (
+                <Text style={styles.errorText}>{errors.username}</Text>
+              )}
+            </View>
+
+            {/* Full Name - Optional */}
+            <View style={styles.inputContainer}>
+              <Text style={[styles.label, dynamicStyles.label]}>
+                Full Name <Text style={styles.optionalLabel}>(optional)</Text>
+              </Text>
+              <TextInput
+                style={[styles.input, dynamicStyles.input]}
+                placeholder="Enter your full name"
+                placeholderTextColor={isDark ? '#666' : '#999'}
+                value={fullName}
+                onChangeText={setFullName}
+                autoCapitalize="words"
+                textContentType="name"
+                autoComplete="name"
+                editable={!loading}
+              />
+            </View>
+
+            {/* Phone Number - Required */}
+            <View style={styles.inputContainer}>
+              <Text style={[styles.label, dynamicStyles.label]}>Phone Number</Text>
+              <TextInput
+                style={[styles.input, dynamicStyles.input, errors.phoneNumber && styles.inputError]}
+                placeholder="Enter your phone number"
+                placeholderTextColor={isDark ? '#666' : '#999'}
+                value={phoneNumber}
+                onChangeText={(text) => {
+                  setPhoneNumber(text);
+                  if (errors.phoneNumber) {
+                    setErrors({ ...errors, phoneNumber: undefined });
+                  }
+                }}
+                keyboardType="phone-pad"
+                textContentType="telephoneNumber"
+                autoComplete="tel"
+                editable={!loading}
+              />
+              {errors.phoneNumber && (
+                <Text style={styles.errorText}>{errors.phoneNumber}</Text>
+              )}
+              <Text style={styles.helperText}>Used for disc recovery notifications</Text>
+            </View>
+
+            {/* Throwing Hand */}
+            <View style={styles.inputContainer}>
+              <Text style={[styles.label, dynamicStyles.label]}>Throwing Hand</Text>
+              <View style={styles.toggleRow}>
+                <TouchableOpacity
+                  style={[
+                    styles.toggleButton,
+                    styles.toggleButtonLeft,
+                    dynamicStyles.toggleButton,
+                    throwingHand === 'right' && dynamicStyles.toggleButtonActive,
+                  ]}
+                  onPress={() => setThrowingHand('right')}
+                  disabled={loading}
+                >
+                  <Text style={[
+                    styles.toggleText,
+                    dynamicStyles.toggleText,
+                    throwingHand === 'right' && dynamicStyles.toggleTextActive,
+                  ]}>
+                    Right
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.toggleButton,
+                    styles.toggleButtonRight,
+                    dynamicStyles.toggleButton,
+                    throwingHand === 'left' && dynamicStyles.toggleButtonActive,
+                  ]}
+                  onPress={() => setThrowingHand('left')}
+                  disabled={loading}
+                >
+                  <Text style={[
+                    styles.toggleText,
+                    dynamicStyles.toggleText,
+                    throwingHand === 'left' && dynamicStyles.toggleTextActive,
+                  ]}>
+                    Left
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+
+            {/* Preferred Throw Style */}
+            <View style={styles.inputContainer}>
+              <Text style={[styles.label, dynamicStyles.label]}>Preferred Throw Style</Text>
+              <View style={styles.toggleRow}>
+                <TouchableOpacity
+                  style={[
+                    styles.toggleButton,
+                    styles.toggleButtonLeft,
+                    dynamicStyles.toggleButton,
+                    preferredThrowStyle === 'backhand' && dynamicStyles.toggleButtonActive,
+                  ]}
+                  onPress={() => setPreferredThrowStyle('backhand')}
+                  disabled={loading}
+                >
+                  <Text style={[
+                    styles.toggleText,
+                    dynamicStyles.toggleText,
+                    preferredThrowStyle === 'backhand' && dynamicStyles.toggleTextActive,
+                  ]}>
+                    Backhand
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.toggleButton,
+                    dynamicStyles.toggleButton,
+                    preferredThrowStyle === 'forehand' && dynamicStyles.toggleButtonActive,
+                  ]}
+                  onPress={() => setPreferredThrowStyle('forehand')}
+                  disabled={loading}
+                >
+                  <Text style={[
+                    styles.toggleText,
+                    dynamicStyles.toggleText,
+                    preferredThrowStyle === 'forehand' && dynamicStyles.toggleTextActive,
+                  ]}>
+                    Forehand
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.toggleButton,
+                    styles.toggleButtonRight,
+                    dynamicStyles.toggleButton,
+                    preferredThrowStyle === 'both' && dynamicStyles.toggleButtonActive,
+                  ]}
+                  onPress={() => setPreferredThrowStyle('both')}
+                  disabled={loading}
+                >
+                  <Text style={[
+                    styles.toggleText,
+                    dynamicStyles.toggleText,
+                    preferredThrowStyle === 'both' && dynamicStyles.toggleTextActive,
+                  ]}>
+                    Both
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+
+            {/* Password */}
             <View style={styles.inputContainer}>
               <Text style={[styles.label, dynamicStyles.label]}>Password</Text>
               <TextInput
@@ -159,6 +385,7 @@ export default function SignUp() {
                 secureTextEntry
                 autoCorrect={false}
                 textContentType="newPassword"
+                autoComplete="password-new"
                 editable={!loading}
               />
               {errors.password && (
@@ -166,6 +393,7 @@ export default function SignUp() {
               )}
             </View>
 
+            {/* Confirm Password */}
             <View style={styles.inputContainer}>
               <Text style={[styles.label, dynamicStyles.label]}>Confirm Password</Text>
               <TextInput
@@ -230,34 +458,40 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     padding: 20,
-    justifyContent: 'center',
+    paddingBottom: 40,
   },
   logoContainer: {
     alignItems: 'center',
-    marginBottom: 48,
+    marginBottom: 32,
+    marginTop: 20,
   },
   logo: {
     width: 180,
     height: 60,
   },
   title: {
-    fontSize: 32,
+    fontSize: 28,
     fontWeight: 'bold',
     marginBottom: 8,
   },
   subtitle: {
     fontSize: 16,
-    marginBottom: 32,
+    marginBottom: 24,
   },
   form: {
     gap: 16,
   },
   inputContainer: {
-    gap: 8,
+    gap: 6,
   },
   label: {
     fontSize: 14,
     fontWeight: '600',
+  },
+  optionalLabel: {
+    fontSize: 12,
+    fontWeight: '400',
+    color: '#999',
   },
   input: {
     borderWidth: 1,
@@ -271,6 +505,33 @@ const styles = StyleSheet.create({
   errorText: {
     color: '#ef4444',
     fontSize: 12,
+  },
+  helperText: {
+    color: '#999',
+    fontSize: 12,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+  },
+  toggleButton: {
+    flex: 1,
+    paddingVertical: 12,
+    alignItems: 'center',
+    borderWidth: 1,
+  },
+  toggleButtonLeft: {
+    borderTopLeftRadius: 8,
+    borderBottomLeftRadius: 8,
+    borderRightWidth: 0,
+  },
+  toggleButtonRight: {
+    borderTopRightRadius: 8,
+    borderBottomRightRadius: 8,
+    borderLeftWidth: 0,
+  },
+  toggleText: {
+    fontSize: 14,
+    fontWeight: '500',
   },
   button: {
     backgroundColor: Colors.violet.primary,

--- a/components/DiscPreferencesSection.tsx
+++ b/components/DiscPreferencesSection.tsx
@@ -6,16 +6,21 @@ import Colors from '@/constants/Colors';
 import { useColorScheme } from '@/components/useColorScheme';
 
 export type ThrowingHand = 'right' | 'left';
+export type PreferredThrowStyle = 'backhand' | 'forehand' | 'both';
 
 interface DiscPreferencesSectionProps {
   throwingHand: ThrowingHand;
   onThrowingHandChange: (hand: ThrowingHand) => void;
+  preferredThrowStyle: PreferredThrowStyle;
+  onPreferredThrowStyleChange: (style: PreferredThrowStyle) => void;
   saving?: boolean;
 }
 
 export default function DiscPreferencesSection({
   throwingHand,
   onThrowingHandChange,
+  preferredThrowStyle,
+  onPreferredThrowStyleChange,
   saving = false,
 }: DiscPreferencesSectionProps) {
   const colorScheme = useColorScheme();
@@ -39,6 +44,41 @@ export default function DiscPreferencesSection({
     );
   }, [onThrowingHandChange]);
 
+  const handlePreferredThrowStylePress = useCallback(() => {
+    Alert.alert(
+      'Preferred Throw Style',
+      'Select your preferred throwing style',
+      [
+        {
+          text: 'Backhand',
+          onPress: () => onPreferredThrowStyleChange('backhand'),
+        },
+        {
+          text: 'Forehand',
+          onPress: () => onPreferredThrowStyleChange('forehand'),
+        },
+        {
+          text: 'Both',
+          onPress: () => onPreferredThrowStyleChange('both'),
+        },
+        { text: 'Cancel', style: 'cancel' },
+      ]
+    );
+  }, [onPreferredThrowStyleChange]);
+
+  const getThrowStyleLabel = (style: PreferredThrowStyle): string => {
+    switch (style) {
+      case 'backhand':
+        return 'Backhand';
+      case 'forehand':
+        return 'Forehand';
+      case 'both':
+        return 'Both';
+      default:
+        return 'Backhand';
+    }
+  };
+
   return (
     <View style={styles.section}>
       <Text style={styles.sectionTitle}>Disc Preferences</Text>
@@ -54,6 +94,23 @@ export default function DiscPreferencesSection({
             disabled={saving}>
             <Text style={styles.detailValue}>
               {throwingHand === 'right' ? 'Right Hand' : 'Left Hand'}
+            </Text>
+            <FontAwesome name="chevron-down" size={12} color="#999" />
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {/* Preferred Throw Style */}
+      <View style={[styles.editableRow, styles.rowBorder]}>
+        <FontAwesome name="repeat" size={16} color="#666" style={styles.detailIcon} />
+        <View style={styles.editableContent}>
+          <Text style={styles.detailLabel}>Preferred Throw Style</Text>
+          <TouchableOpacity
+            style={styles.dropdownRow}
+            onPress={handlePreferredThrowStylePress}
+            disabled={saving}>
+            <Text style={styles.detailValue}>
+              {getThrowStyleLabel(preferredThrowStyle)}
             </Text>
             <FontAwesome name="chevron-down" size={12} color="#999" />
           </TouchableOpacity>
@@ -84,6 +141,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-start',
     paddingVertical: 12,
+  },
+  rowBorder: {
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(150, 150, 150, 0.2)',
   },
   detailIcon: {
     marginRight: 12,

--- a/components/FlightPath.tsx
+++ b/components/FlightPath.tsx
@@ -80,11 +80,11 @@ export default function FlightPath({
     anhyzer: selectedPath === null || selectedPath === 'anhyzer',
   }), [selectedPath]);
 
-  // Fetch user's throwing hand preference
+  // Fetch user's throwing hand and preferred throw style
   useEffect(() => {
     let isMounted = true;
 
-    async function fetchThrowingHand() {
+    async function fetchUserPreferences() {
       try {
         const {
           data: { user },
@@ -93,19 +93,24 @@ export default function FlightPath({
 
         const { data, error } = await supabase
           .from('profiles')
-          .select('throwing_hand')
+          .select('throwing_hand, preferred_throw_style')
           .eq('id', user.id)
           .single();
 
-        if (!error && data?.throwing_hand && isMounted) {
-          setThrowingHand(data.throwing_hand as ThrowingHand);
+        if (!error && data && isMounted) {
+          if (data.throwing_hand) {
+            setThrowingHand(data.throwing_hand as ThrowingHand);
+          }
+          if (data.preferred_throw_style && data.preferred_throw_style !== 'both') {
+            setThrowStyle(data.preferred_throw_style as ThrowStyle);
+          }
         }
       } catch {
-        // Use default (right) if fetch fails
+        // Use defaults if fetch fails
       }
     }
 
-    fetchThrowingHand();
+    fetchUserPreferences();
 
     return () => {
       isMounted = false;

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -20,12 +20,20 @@ Notifications.setNotificationHandler({
   }),
 });
 
+interface SignUpMetadata {
+  username?: string;
+  full_name?: string;
+  phone_number?: string;
+  throwing_hand?: 'right' | 'left';
+  preferred_throw_style?: 'backhand' | 'forehand' | 'both';
+}
+
 type AuthContextType = {
   session: Session | null;
   user: User | null;
   loading: boolean;
   signIn: (email: string, password: string) => Promise<{ error: Error | null }>;
-  signUp: (email: string, password: string) => Promise<{ error: Error | null }>;
+  signUp: (email: string, password: string, metadata?: SignUpMetadata) => Promise<{ error: Error | null }>;
   signInWithGoogle: () => Promise<{ error: Error | null }>;
   signOut: () => Promise<void>;
   registerPushToken: () => Promise<void>;
@@ -246,10 +254,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return { error };
   };
 
-  const signUp = async (email: string, password: string) => {
+  const signUp = async (email: string, password: string, metadata?: SignUpMetadata) => {
     const { error } = await supabase.auth.signUp({
       email,
       password,
+      options: metadata ? { data: metadata } : undefined,
     });
     if (error) {
       captureError(error, { operation: 'signUp', email });

--- a/lib/validation.test.ts
+++ b/lib/validation.test.ts
@@ -4,6 +4,9 @@ import {
   validatePasswordMatch,
   validateSignInForm,
   validateSignUpForm,
+  validateUsername,
+  validatePhoneNumber,
+  validateFullSignUpForm,
 } from './validation';
 
 describe('validateEmail', () => {
@@ -147,5 +150,125 @@ describe('validateSignUpForm', () => {
     expect(errors.email).toBe('Email is required');
     expect(errors.password).toBe('Password must be at least 8 characters');
     expect(errors.confirmPassword).toBe('Passwords do not match');
+  });
+
+  it('should validate username when provided', () => {
+    const errors = validateSignUpForm('test@example.com', 'password123', 'password123', 'ab');
+    expect(errors.username).toBe('Username must be at least 3 characters');
+  });
+
+  it('should accept valid username', () => {
+    const errors = validateSignUpForm('test@example.com', 'password123', 'password123', 'validuser');
+    expect(errors.username).toBeUndefined();
+  });
+});
+
+describe('validateUsername', () => {
+  it('should return null for valid usernames', () => {
+    expect(validateUsername('john_doe')).toBeNull();
+    expect(validateUsername('user123')).toBeNull();
+    expect(validateUsername('test-user')).toBeNull();
+  });
+
+  it('should return null for empty username when not required', () => {
+    expect(validateUsername('')).toBeNull();
+    expect(validateUsername('   ')).toBeNull();
+  });
+
+  it('should return error for empty username when required', () => {
+    expect(validateUsername('', true)).toBe('Username is required');
+    expect(validateUsername('   ', true)).toBe('Username is required');
+  });
+
+  it('should return error for username shorter than 3 characters', () => {
+    expect(validateUsername('ab')).toBe('Username must be at least 3 characters');
+    expect(validateUsername('a')).toBe('Username must be at least 3 characters');
+  });
+
+  it('should return error for username longer than 30 characters', () => {
+    expect(validateUsername('a'.repeat(31))).toBe('Username must be less than 30 characters');
+  });
+
+  it('should return error for username with invalid characters', () => {
+    expect(validateUsername('user@name')).toBe('Username can only contain letters, numbers, underscores, and hyphens');
+    expect(validateUsername('user name')).toBe('Username can only contain letters, numbers, underscores, and hyphens');
+    expect(validateUsername('user.name')).toBe('Username can only contain letters, numbers, underscores, and hyphens');
+  });
+});
+
+describe('validatePhoneNumber', () => {
+  it('should return null for valid phone numbers', () => {
+    expect(validatePhoneNumber('1234567890')).toBeNull();
+    expect(validatePhoneNumber('+11234567890')).toBeNull();
+    expect(validatePhoneNumber('(123) 456-7890')).toBeNull();
+    expect(validatePhoneNumber('123-456-7890')).toBeNull();
+  });
+
+  it('should return null for empty phone when not required', () => {
+    expect(validatePhoneNumber('')).toBeNull();
+    expect(validatePhoneNumber('   ')).toBeNull();
+  });
+
+  it('should return error for empty phone when required', () => {
+    expect(validatePhoneNumber('', true)).toBe('Phone number is required');
+    expect(validatePhoneNumber('   ', true)).toBe('Phone number is required');
+  });
+
+  it('should return error for invalid phone number format', () => {
+    expect(validatePhoneNumber('123')).toBe('Please enter a valid phone number');
+    expect(validatePhoneNumber('abcdefghij')).toBe('Please enter a valid phone number');
+    expect(validatePhoneNumber('12345')).toBe('Please enter a valid phone number');
+  });
+});
+
+describe('validateFullSignUpForm', () => {
+  const validData = {
+    email: 'test@example.com',
+    password: 'password123',
+    confirmPassword: 'password123',
+    username: 'testuser',
+    phoneNumber: '1234567890',
+    throwingHand: 'right',
+    preferredThrowStyle: 'backhand',
+  };
+
+  it('should return no errors for valid data', () => {
+    const errors = validateFullSignUpForm(validData);
+    expect(Object.keys(errors)).toHaveLength(0);
+  });
+
+  it('should return error for invalid email', () => {
+    const errors = validateFullSignUpForm({ ...validData, email: '' });
+    expect(errors.email).toBe('Email is required');
+  });
+
+  it('should return error for invalid password', () => {
+    const errors = validateFullSignUpForm({ ...validData, password: '123', confirmPassword: '123' });
+    expect(errors.password).toBe('Password must be at least 8 characters');
+  });
+
+  it('should return error for mismatched passwords', () => {
+    const errors = validateFullSignUpForm({ ...validData, confirmPassword: 'different' });
+    expect(errors.confirmPassword).toBe('Passwords do not match');
+  });
+
+  it('should return error for invalid username', () => {
+    const errors = validateFullSignUpForm({ ...validData, username: 'ab' });
+    expect(errors.username).toBe('Username must be at least 3 characters');
+  });
+
+  it('should return error for missing required username', () => {
+    const errors = validateFullSignUpForm({ ...validData, username: '' });
+    expect(errors.username).toBe('Username is required');
+  });
+
+  it('should return error for invalid phone number', () => {
+    const errors = validateFullSignUpForm({ ...validData, phoneNumber: '123' });
+    expect(errors.phoneNumber).toBe('Please enter a valid phone number');
+  });
+
+  it('should return error for missing required phone', () => {
+    const errors = validateFullSignUpForm({ ...validData, phoneNumber: '' });
+    expect(errors.phoneNumber).toBe('Phone number is required');
   });
 });

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -48,16 +48,65 @@ export const validateSignInForm = (
   return errors;
 };
 
+export const validateUsername = (username: string, required = false): string | null => {
+  const trimmed = username.trim();
+  if (!trimmed) {
+    return required ? 'Username is required' : null;
+  }
+  if (trimmed.length < 3) {
+    return 'Username must be at least 3 characters';
+  }
+  if (trimmed.length > 30) {
+    return 'Username must be less than 30 characters';
+  }
+  // Only allow alphanumeric, underscores, and hyphens
+  if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+    return 'Username can only contain letters, numbers, underscores, and hyphens';
+  }
+  return null;
+};
+
+export const validatePhoneNumber = (phone: string, required = false): string | null => {
+  const trimmed = phone.trim().replace(/[\s\-\(\)]/g, '');
+  if (!trimmed) {
+    return required ? 'Phone number is required' : null;
+  }
+  // Accept formats: 1234567890, +11234567890, etc.
+  if (!/^\+?1?\d{10,14}$/.test(trimmed)) {
+    return 'Please enter a valid phone number';
+  }
+  return null;
+};
+
+export interface SignUpFormData {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  username: string;
+  fullName?: string;
+  phoneNumber: string;
+  throwingHand: string;
+  preferredThrowStyle: string;
+}
+
+export interface SignUpFormErrors {
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  username?: string;
+  fullName?: string;
+  phoneNumber?: string;
+  throwingHand?: string;
+  preferredThrowStyle?: string;
+}
+
 export const validateSignUpForm = (
   email: string,
   password: string,
-  confirmPassword: string
-): { email?: string; password?: string; confirmPassword?: string } => {
-  const errors: {
-    email?: string;
-    password?: string;
-    confirmPassword?: string;
-  } = {};
+  confirmPassword: string,
+  username?: string
+): SignUpFormErrors => {
+  const errors: SignUpFormErrors = {};
   const trimmedEmail = email.trim();
 
   if (!trimmedEmail) {
@@ -75,6 +124,53 @@ export const validateSignUpForm = (
   if (passwordMatchError) {
     errors.confirmPassword = passwordMatchError;
   }
+
+  if (username) {
+    const usernameError = validateUsername(username);
+    if (usernameError) {
+      errors.username = usernameError;
+    }
+  }
+
+  return errors;
+};
+
+export const validateFullSignUpForm = (data: SignUpFormData): SignUpFormErrors => {
+  const errors: SignUpFormErrors = {};
+  const trimmedEmail = data.email.trim();
+
+  // Email validation
+  if (!trimmedEmail) {
+    errors.email = STRINGS.VALIDATION.EMAIL_REQUIRED;
+  } else if (!validateEmail(trimmedEmail)) {
+    errors.email = STRINGS.VALIDATION.EMAIL_INVALID;
+  }
+
+  // Password validation
+  const passwordError = validatePassword(data.password);
+  if (passwordError) {
+    errors.password = passwordError;
+  }
+
+  // Confirm password validation
+  const passwordMatchError = validatePasswordMatch(data.password, data.confirmPassword);
+  if (passwordMatchError) {
+    errors.confirmPassword = passwordMatchError;
+  }
+
+  // Username validation (required)
+  const usernameError = validateUsername(data.username, true);
+  if (usernameError) {
+    errors.username = usernameError;
+  }
+
+  // Phone number validation (required)
+  const phoneError = validatePhoneNumber(data.phoneNumber, true);
+  if (phoneError) {
+    errors.phoneNumber = phoneError;
+  }
+
+  // Throwing hand and preferred throw style are optional (have defaults)
 
   return errors;
 };


### PR DESCRIPTION
## Summary
- Fix found badge readability (blue instead of violet-on-violet)
- Add preferred throwing style option (backhand/forehand/both)
- Enhanced sign-up with username, phone, throwing hand, throw style
- Username auto-populates from email prefix
- FlightPath uses user preferences as defaults
- Add delete account button with confirmation dialog

## Test plan
- [ ] Verify found badge is readable (blue color)
- [ ] Test preferred throw style selection on profile
- [ ] Test enhanced sign-up flow with all new fields
- [ ] Verify username auto-populates from email
- [ ] Check FlightPath defaults to user preferences
- [ ] Test delete account flow with confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)