### PR TITLE
fix: improve dark mode visibility on forgot password screen

### DIFF
--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -16,8 +16,7 @@ import { Link, router } from 'expo-router';
 import { supabase } from '@/lib/supabase';
 import Colors from '@/constants/Colors';
 
-const logoLight = require('@/assets/images/logo.png');
-const logoDark = require('@/assets/images/logo-white.png');
+const logo = require('@/assets/images/logo.png');
 
 export default function ForgotPassword() {
   const colorScheme = useColorScheme();
@@ -95,6 +94,9 @@ export default function ForgotPassword() {
     label: {
       color: isDark ? '#fff' : '#000',
     },
+    link: {
+      color: isDark ? Colors.violet[400] : Colors.violet.primary,
+    },
   };
 
   return (
@@ -105,7 +107,7 @@ export default function ForgotPassword() {
       <View style={styles.content}>
         <View style={styles.logoContainer}>
           <Image
-            source={isDark ? logoDark : logoLight}
+            source={logo}
             style={styles.logo}
             resizeMode="contain"
             testID="app-logo"
@@ -123,7 +125,7 @@ export default function ForgotPassword() {
             <TextInput
               style={[styles.input, dynamicStyles.input, error ? styles.inputError : null]}
               placeholder="Enter your email"
-              placeholderTextColor={isDark ? '#666' : '#999'}
+              placeholderTextColor={isDark ? '#888' : '#999'}
               value={email}
               onChangeText={(text) => {
                 setEmail(text);
@@ -152,8 +154,8 @@ export default function ForgotPassword() {
 
           <View style={styles.footer}>
             <Link href="/(auth)/sign-in" asChild>
-              <TouchableOpacity disabled={loading}>
-                <Text style={styles.link}>Back to Sign In</Text>
+              <TouchableOpacity disabled={loading} hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}>
+                <Text style={[styles.link, dynamicStyles.link]}>Back to Sign In</Text>
               </TouchableOpacity>
             </Link>
           </View>
@@ -233,7 +235,6 @@ const styles = StyleSheet.create({
     marginTop: 16,
   },
   link: {
-    color: Colors.violet.primary,
     fontSize: 14,
     fontWeight: '600',
   },


### PR DESCRIPTION
## Summary

Fixes dark mode visibility issues on the forgot password screen (consistent with sign-in/sign-up screens):

- Use purple logo for both light and dark modes (was white in dark mode)
- Use brighter violet (`Colors.violet[400]`) for "Back to Sign In" link in dark mode
- Increase placeholder text contrast (`#888` vs `#666`) in dark mode
- Add `hitSlop` to "Back to Sign In" link for larger tap target

## Backend Issues (Not in this PR)

The following email-related issues require Supabase configuration changes and are tracked separately in issue #307:

- Email delivery slow (5+ minutes)
- Email marked as spam in Gmail
- No email theming/branding
- Wrong sender name ("Aceback" instead of "Discr")
- Suspicious link warning when clicking reset
- Wrong redirect domain (aceback.app)

## Test plan

- [ ] Manual test in dark mode:
  - [ ] Logo shows purple text
  - [ ] "Back to Sign In" link is clearly visible and easy to tap
  - [ ] Placeholder text is readable

Closes #307 (mobile UI portion only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)