### PR TITLE
fix: correct password reset redirect URL scheme

### DIFF
--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -50,7 +50,7 @@ export default function ForgotPassword() {
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(
         email.trim(),
         {
-          redirectTo: 'com.discrapp.com://reset-password',
+          redirectTo: 'com.discr.app://reset-password',
         }
       );
 


### PR DESCRIPTION
## Summary

Fixes the password reset redirect URL scheme bug.

**Before:** `com.discrapp.com://reset-password`
**After:** `com.discr.app://reset-password`

The redirect URL was using the wrong scheme (`com.discrapp.com`) which doesn't match the app's registered URL scheme (`com.discr.app` defined in app.json). This was causing password reset links to not open the app correctly.

## Test plan

- [ ] Request a password reset
- [ ] Click the link in the email
- [ ] Verify the app opens to the reset password screen

Related to #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)