### PR TITLE
chore: enable platform automerge for Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
   "commitMessageExtra": "to {{newValue}}",
   "commitMessageTopic": "{{depName}}",
   "automerge": false,
-  "platformAutomerge": false,
+  "platformAutomerge": true,
   "rebaseWhen": "behind-base-branch",
   "labels": [
     "dependencies",


### PR DESCRIPTION
## Summary
- Enables `platformAutomerge: true` in Renovate config
- Renovate PRs with `automerge: true` will now use GitHub's native auto-merge feature
- Works with the merge queue ruleset to ensure checks pass before merging

## Test plan
- [ ] Verify Renovate creates PRs with auto-merge enabled
- [ ] Confirm PRs enter the merge queue and merge after checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)