### PR TITLE
chore: add Renovate grouping rules and remove PR limits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,8 @@
   "automerge": false,
   "platformAutomerge": true,
   "rebaseWhen": "behind-base-branch",
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "labels": [
     "dependencies",
     "renovate"
@@ -36,6 +38,24 @@
     ]
   },
   "packageRules": [
+    {
+      "description": "Group all non-major npm updates together",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
+      "groupName": "npm non-major updates"
+    },
+    {
+      "description": "Group all major npm updates together",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "npm major updates"
+    },
+    {
+      "description": "Automerge minor/patch updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
     {
       "description": "Disable Expo ecosystem packages - managed by `npx expo install --fix`",
       "enabled": false,
@@ -71,39 +91,23 @@
       }
     },
     {
-      "description": "Group testing packages",
-      "groupName": "testing packages",
-      "matchPackageNames": [
-        "/jest/",
-        "/testing-library/"
-      ]
-    },
-    {
-      "description": "GitHub Actions - automerge patch/minor",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "description": "GitHub Actions - group and automerge non-major",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github-actions non-major",
       "automerge": true,
       "automergeType": "pr"
     },
     {
-      "description": "Pre-commit hooks - group updates",
-      "matchManagers": [
-        "pre-commit"
-      ],
-      "groupName": "pre-commit hooks"
+      "description": "GitHub Actions - group major updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "github-actions major"
     },
     {
-      "description": "TypeScript and types - group together",
-      "groupName": "typescript and types",
-      "matchPackageNames": [
-        "/^typescript/",
-        "/^@types//"
-      ]
+      "description": "Pre-commit hooks - group updates",
+      "matchManagers": ["pre-commit"],
+      "groupName": "pre-commit hooks"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Set `prConcurrentLimit: 0` and `prHourlyLimit: 0` to remove PR limits
- Group all npm non-major updates into single PR (auto-merges)
- Group all npm major updates into single PR (manual review)
- Group GitHub Actions non-major updates (auto-merges)
- Group GitHub Actions major updates (manual review)
- Add automerge for all minor/patch updates
- Remove redundant testing/typescript groupings (now covered by npm grouping)

## Test plan
- [ ] Trigger Renovate and verify grouped PRs are created
- [ ] Verify auto-merge works on minor/patch PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)