### PR TITLE
chore: enable Renovate to auto-close superseded PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,7 @@
   "rebaseWhen": "behind-base-branch",
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
+  "pruneStaleBranches": true,
   "labels": [
     "dependencies",
     "renovate"


### PR DESCRIPTION
## Summary
- Adds `pruneStaleBranches: true` to automatically close PRs that have been superseded by grouped PRs

## Test plan
- [ ] Merge and trigger Renovate
- [ ] Verify old individual PRs are automatically closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)