### PR TITLE
fix: only rebase Renovate PRs on conflict

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
   "commitMessageTopic": "{{depName}}",
   "automerge": false,
   "platformAutomerge": true,
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "conflicted",
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "pruneStaleBranches": true,


### PR DESCRIPTION
## Summary
- Changes `rebaseWhen` from `"behind-base-branch"` to `"conflicted"`
- PRs will only rebase when there's an actual merge conflict, not just when main has new commits
- This prevents the cascade of rebases when multiple PRs are open

## Test plan
- [ ] Merge and verify PRs don't get rebased unnecessarily

🤖 Generated with [Claude Code](https://claude.com/claude-code)