### PR TITLE
fix: add babel-preset-expo as explicit devDependency for @babel/core 7.29.x compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.14",
         "@types/react": "~19.1.10",
+        "babel-preset-expo": "~54.0.10",
         "jest": "^29.7.0",
         "jest-expo": "~54.0.14",
         "prettier": "^3.7.4",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@testing-library/jest-native": "^5.4.3",
+    "babel-preset-expo": "~54.0.10",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.1.10",


### PR DESCRIPTION
@babel/core 7.29.x changed module resolution and can no longer find `babel-preset-expo` through transitive deps (it was previously provided by `expo`). Adding it explicitly as a devDependency fixes the `Cannot find module 'babel-preset-expo'` test failures on the Renovate npm non-major and major PRs.